### PR TITLE
docs: use Markdown instead of capital case for symbol references

### DIFF
--- a/core/chain.lisp
+++ b/core/chain.lisp
@@ -42,7 +42,8 @@
     :accessor chain-supplier-network
     :initarg :network
     :initform :mainnet
-    :documentation "Network marker (one of :MAINNET, :TESTNET, :REGTEST).")))
+    :documentation "Network marker (one of `:mainnet`, `:testnet`, `:regtest`).")))
+
 
 (define-condition unknown-entity-error (simple-error)
   ())
@@ -72,38 +73,38 @@
      (format s "Unknown transaction ~a." (unknown-transaction-id e)))))
 
 (defgeneric chain-network (supplier)
-  (:documentation "Return keyword representing the given SUPPLIER's
-network (one of :MAINNET, :TESTNET, :REGTEST).")
+  (:documentation "Return keyword representing the given `supplier`'s
+network (one of `:mainnet`, `:testnet`, `:regtest`).")
   (:method (supplier)
     (chain-supplier-network supplier)))
 
 (defgeneric chain-testnet-p (supplier)
-  (:documentation "Return NIL if SUPPLIER's network is :MAINNET and T
+  (:documentation "Return `nil` if `supplier`'s network is `:mainnet` and `t`
 otherwise.")
   (:method (supplier)
     (not (eq (chain-supplier-network supplier) :mainnet))))
 
 (defgeneric chain-get-block-hash (supplier height &key encoded errorp)
-  (:documentation "Get the hash of the block from SUPPLIER by its
-HEIGHT in the chain. HEIGHT must be an integer. If ENCODED is non-NIL,
+  (:documentation "Get the hash of the block from `supplier` by its
+`height` in the chain. `height` must be an integer. If `encoded` is non-`nil`,
 returns a hex-encoded string, otherwise returns a raw id represented
-as byte array. If there is no known block at the given HEIGHT, return
-NIL or signal an UNKNOWN-BLOCK-HASH-ERROR error, depending on the
-ERRORP value."))
+as byte array. If there is no known block at the given `height`, return
+`nil` or signal an `unknown-block-hash-error` error, depending on the
+`errorp` value."))
 
 (defgeneric chain-get-block (supplier hash &key encoded errorp)
-  (:documentation "Get raw block data from SUPPLIER by its HASH. HASH
-can be either a hex-encoded string or a byte array. If ENCODED is
-non-NIL, returns a hex-encoded string, otherwise returns CBLOCK
-object. If there is no block with the given HASH, return NIL or signal
-an UNKNOWN-BLOCK-ERROR error, depending on the ERRORP value."))
+  (:documentation "Get raw block data from `supplier` by its `hash`. `hash`
+can be either a hex-encoded string or a byte array. If `encoded` is
+non-`nil`, returns a hex-encoded string, otherwise returns `cblock`
+object. If there is no block with the given `hash`, return `nil` or signal
+an `unknown-block-error` error, depending on the `errorp` value."))
 
 (defgeneric chain-get-transaction (supplier id &key encoded errorp)
-  (:documentation "Get raw transaction data from SUPPLIER by its
-ID. ID can be either a hex-encoded string or a byte array. If ENCODED
-is non-NIL, returns a hex-encoded string, otherwise returns TX
-object. If there is no transaction with a given ID, return NIL or
-signal an UNKNOWN-TRANSACTION-ERROR error, depending on the ERRORP
+  (:documentation "Get raw transaction data from `supplier` by its
+`id`. `id` can be either a hex-encoded string or a byte array. If `encoded`
+is non-`nil`, returns a hex-encoded string, otherwise returns `tx`
+object. If there is no transaction with a given `id`, return `nil` or
+signal an `unknown-transaction-error` error, depending on the `errorp`
 value."))
 
 
@@ -116,21 +117,21 @@ value."))
                                              &body body)
   "Helper macro for generating the normalization if the entity
 identifier (block height, block hash and transaction id) and
-post-processing (encoding, decoding and error signalling) for the
-chain supplier API implementations.  
+post-processing (encoding, decoding and error signaling) for the
+chain supplier API implementations.
 
-ID-VAR is an entity identifier variable, which will be normalized to a
-hex-string, byte array or left unchanged if the value of ID-TYPE is
-:ENCODED, :DECODED or :AS-IS respectively.
+`id-var` is an entity identifier variable, which will be normalized to a
+hex-string, byte array or left unchanged if the value of `id-type` is
+`:encoded`, `:decoded` or `:as-is` respectively.
 
-ENCODED-VAR corresponds to ENCODED chain supplier parameter - it will
-be used in combination with BODY-TYPE argument to determine if the
-result of the BODY should be encoded, decoded (as an ENTITY-TYPE
+`encoded-var` corresponds to `encoded` chain supplier parameter - it will
+be used in combination with `body-type` argument to determine if the
+result of the `body` should be encoded, decoded (as an `entity-type`
 entity in the latter case) or left as-is.
 
-ERROPR-VAR corresponds to the ERRORP chain supplier parameter - it
-will be used to either return NIL or signal a corresponding error if
-the body returns NIL. If ERROR-TYPE is non-NIL, it will be used
+`errorp-var` corresponds to the `errorp` chain supplier parameter - it
+will be used to either return `nil` or signal a corresponding error if
+the body returns `nil`. If `error-type` is non-`nil`, it will be used
 instead of the default error type."
   (let* ((result (gensym "chain-supplier-result"))
          (id-form
@@ -177,7 +178,7 @@ instead of the default error type."
 ;;; Context-dependent API
 
 (defvar *chain-supplier* nil
-  "Global chain supplier bound by the WITH-CHAIN-SUPPLIER context manager.")
+  "Global chain supplier bound by the `with-chain-supplier` context manager.")
 
 (defmacro with-chain-supplier ((type &rest args &key &allow-other-keys) &body body)
   `(let ((*chain-supplier* (make-instance ',type ,@args)))

--- a/core/consensus.lisp
+++ b/core/consensus.lisp
@@ -20,10 +20,10 @@
 
 
 ;;; The definitions in this file contain Bitcoin consensus rules. The
-;;; top-level consensus API consists of two functions: VALIDATE, which
-;;; returns T if an entity from the model is valid, and signals an
-;;; explanatory error otherwise, and a wrapping VALIDP predicate,
-;;; which ignores the errors and retuns NIL in the latter case.
+;;; top-level consensus API consists of two functions: `validate`, which
+;;; returns `t` if an entity from the model is valid, and signals an
+;;; explanatory error otherwise, and a wrapping `validp` predicate,
+;;; which ignores the errors and retuns `nil` in the latter case.
 ;;;
 ;;; Bitcoin Consensus rules are particularly hard to reimplement,
 ;;; since there is a lot of corner cases (caused by engineering
@@ -46,7 +46,7 @@
 consensus rules, throw an error if an entity is invalid for any reason."))
 
 (defun validp (entity &key context)
-  "Return T if the ENTITY is valid, NIL otherwise."
+  "Return `t` if `entity` is valid, `nil` otherwise."
   (ignore-errors (validate entity :context context)))
 
 (defclass validation-context ()
@@ -62,15 +62,15 @@ consensus rules, throw an error if an entity is invalid for any reason."))
 during entity validation."))
 
 (defmacro ensure-validation-context ((context-sym) &body body)
-  "Ensure CONTEXT-SYM is bound to the VALIDATION-CONTEXT object before
-executing the BODY."
+  "Ensure `context-sym` is bound to the `validation-context` object before
+executing the `body`."
   (assert (symbolp context-sym))
   `(let ((,context-sym (or ,context-sym (make-instance 'validation-context))))
      ,@body))
 
 (defun extend-validation-context (context &key height block tx tx-index txin
                                             txin-index txout txout-index)
-  "Create a new VALIDATION-CONTEXT object from the given one and
+  "Create a new `validation-context` object from the given one and
 extend it with additional data if supplied."
   (make-instance
    'validation-context
@@ -160,9 +160,9 @@ extend it with additional data if supplied."
         (let ((fhash (make-byte-array 32)))
           (setf (aref fhash 31) 1)
           (return-from tx-sighash-base fhash)))
-      ;; Resize output vector to TXIN-INDEX + 1 outputs.
+      ;; Resize output vector to `txin-index` + 1 outputs.
       (setf (tx-outputs tx) (subseq (tx-outputs tx) 0 (1+ txin-index)))
-      ;; Set each output's (except the TXIN-INDEXth one) to empty
+      ;; Set each output's (except the `txin-index`th one) to empty
       ;; script and value of -1.
       (loop
          :for i :below (length (tx-outputs tx))

--- a/core/encoding.lisp
+++ b/core/encoding.lisp
@@ -162,21 +162,21 @@
 ;;; Entity encoding/decoding API
 
 (defgeneric serialize (entity stream)
-  (:documentation "Serialize ENTITY into the stream."))
+  (:documentation "Serialize `entity` into `stream`."))
 
 (defgeneric parse (entity-class stream)
-  (:documentation "Parse bytes from the STREAM into an instance
-  of the class named ENTITY-CLASS."))
+  (:documentation "Parse bytes from the `stream` into an instance
+of the class named `entity-class`."))
 
 (defun encode (entity)
-  "Encode Bitcoin Protocol ENTITY into a hex string."
+  "Encode Bitcoin Protocol `entity` into a hex string."
   (hex-encode
    (with-output-to-byte-array (stream)
      (serialize entity stream))))
 
 (defun decode (entity-class string)
-  "Decode Bitcoin Protocol entity given by its class name ENTITY-CLASS
-from hex STRING."
+  "Decode Bitcoin Protocol entity given by its class name `entity-class`
+from hex `string`."
   (with-input-from-byte-array (stream (hex-decode string))
     (parse entity-class stream)))
 
@@ -189,8 +189,8 @@ from hex STRING."
 
 (defmacro define-alphabet (name &body (charset &key case-insensitive))
   "Define two functions for encoding/decoding digits of a given
-encoding scheme named <NAME>-ENCODE-DIGIT and <NAME>-DECODE-DIGIT
-respective."
+encoding scheme named `<name>-encode-digit` and `<name>-decode-digit`
+respectively."
   (assert (symbolp name) (name) "Alphabet name ~s is not a symbol." name)
   (assert (stringp charset) (charset) "Alphabet charset ~s is not a string." charset)
   (flet ((combine-symbols (&rest symbols)
@@ -299,7 +299,7 @@ respective."
       bytes)))
 
 (defun base58check-encode (bytes)
-  "BASE58-encode a byte array BYTES (payload) followed by the checksum
+  "BASE58-encode a byte array `bytes` (payload) followed by the checksum
 computed as first 4 bytes of the double-SHA256 hash of the payload."
   (let* ((bytes-length (length bytes))
          (bytes/checksum-length (+ 4 bytes-length))
@@ -311,7 +311,7 @@ computed as first 4 bytes of the double-SHA256 hash of the payload."
     (base58-encode bytes/checksum)))
 
 (defun base58check-decode (string)
-  "Decode a BASE58-encoded string STRING, verify that the last 4
+  "Decode a BASE58-encoded string `string`, verify that the last 4
 bytes (checksum part) match the first 4 bytes of the double-SHA256
 hash of all but the last 4 bytes of the original sequence (payload
 part) and return the payload part."
@@ -382,7 +382,7 @@ part) and return the payload part."
 
 (defun bech32-verify-checksum (hrp data)
   "Verify checksum using the both Bech32 and Bech32m constants.
-Return the detected encoding or NIL if neither match."
+Return the detected encoding or `nil` if neither match."
   (let ((polymod (bech32-polymod (concatenate 'vector (bech32-hrp-expand hrp) data))))
     (cond ((= polymod +bech32-encoding-constant+)
            :bech32)
@@ -401,7 +401,7 @@ Return the detected encoding or NIL if neither match."
 
 (defun convert-bits (values from-bits to-bits padp output-fn)
   "Convert from one power-of-2 number base to another. Feed each digit
-to the function OUTPUT-FN. We only need this to work for octets for
+to the function `output-fn`. We only need this to work for octets for
 now. A direct translation from Bitcoin Core's `ConvertBits` function
 in `util/strencoding.h`."
   (assert (and (typep from-bits 'integer) (<= 1 from-bits 8))

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -30,7 +30,7 @@
 (defstruct script
   commands)
 
-;;; Script's COMMANDS slot is an array of commands, each of which is either
+;;; Script's `commands` slot is an array of commands, each of which is either
 ;;;
 ;;;   - an integer for a simple command (like OP_0, OP_DUP etc),
 ;;;
@@ -120,10 +120,10 @@ otherwise."
 (defun register-opcode (code name &optional function)
   (let ((name (intern (string name) :keyword)))
     (if function
-        ;; If FUNCTION is present, this is opcode definition.
+        ;; If `function` is present, this is the opcode definition.
         (setf (gethash code *opcodes-by-code*) (cons (list name) function)
               (gethash name *opcodes-by-name*) (cons code        function))
-        ;; Otherwise, this is an opcode alias definition.
+        ;; Otherwise, this is the opcode alias definition.
         (push name (car (gethash code *opcodes-by-code*))))))
 
 (defun decode-integer (bytes)
@@ -229,7 +229,7 @@ otherwise."
     (make-script :commands (coerce (reverse commands) 'vector))))
 
 (defvar *print-script-as-assembly* nil
-  "If non-NIL, the script will be printed without Lisp object wrapping.")
+  "If non-`nil`, the script will be printed without Lisp object wrapping.")
 
 (defmethod print-object ((script script) stream)
   (flet ((print-command  (c)
@@ -250,7 +250,7 @@ otherwise."
             (format stream "<~{~a~^ ~}>" commands))))))
 
 (defun script (&rest symbolic-commands)
-  "Construct a SCRIPT object from a sequence of Lisp objects, doing
+  "Construct a `script` object from a sequence of Lisp objects, doing
 the best effort to detect/convert the provided values."
   (flet ((command (symbolic-command)
            (etypecase symbolic-command
@@ -298,7 +298,7 @@ the best effort to detect/convert the provided values."
   (format stream "Non-standard script: ~a." (script-error-script condition)))
 
 (defun p2pk-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates a standard obsolete p2pk
+  "Check if given `script-pubkey` indicates a standard obsolete P2PK
 pattern:
     <pubkkey>
     OP_CHECKSIG"
@@ -308,7 +308,7 @@ pattern:
          (= (command-opcode (aref commands 1)) (opcode :op_checksig)))))
 
 (defun p2ms-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates a standard obsolete p2ms
+  "Check if given `script-pubkey` indicates a standard obsolete P2MS
 pattern:
     OP_<N>
     <key 1>
@@ -325,14 +325,14 @@ pattern:
          (every #'command-payload (subseq commands 1 (- length 2))))))
 
 (defun null-data-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY is a NULL DATA script."
+  "Check if given `script-pubkey` is a NULL DATA script."
   (let ((commands (script-commands script-pubkey)))
     (and (= (length commands) 2)
          (= (command-opcode (aref commands 0)) (opcode :op_return))
          (command-payload (aref commands 1)))))
 
 (defun p2pkh-p (script-pubkey)
-  "Check if current SCRIPT-PUBKEY indicates a standard p2pkh pattern:
+  "Check if current `script-pubkey` indicates a standard P2PKH pattern:
     OP_DUP
     OP_HASH160
     <hash160>
@@ -347,7 +347,7 @@ pattern:
          (= (command-opcode (aref commands 4)) (opcode :op_checksig)))))
 
 (defun p2sh-p (script-pubkey)
-  "Check if current SCRIPT-PUBKEY indicates the BIP 0016 (p2sh)
+  "Check if current `script-pubkey` indicates the BIP 0016 (P2SH)
 pattern:
     <redeem-script>
     OP_HASH160
@@ -362,7 +362,7 @@ pattern:
          (= (command-opcode (aref commands 2)) (opcode :op_equal)))))
 
 (defun segwit-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates the BIP 0141 (Segregated
+  "Check if given `script-pubkey` indicates the BIP 0141 (Segregated
 Witness) structure:
     <version-byte>    (1 byte, OP_{0..16})
     <witness-program> (2-40 bytes)"
@@ -378,7 +378,7 @@ Witness) structure:
          (<= 2 (length program) 40))))))
 
 (defun p2wpkh-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates a Pay to Witness Public Key Hash
+  "Check if given `script-pubkey` indicates a Pay to Witness Public Key Hash
 script structure:
     OP_0
     <20-byte witness-program>"
@@ -388,7 +388,7 @@ script structure:
    (= 20 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun p2wsh-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates a Pay to Witness Script Hash
+  "Check if given `script-pubkey` indicates a Pay to Witness Script Hash
 script structure:
     OP_0
     <32-byte witness-program>"
@@ -398,7 +398,7 @@ script structure:
    (= 32 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun p2tr-p (script-pubkey)
-  "Check if given SCRIPT-PUBKEY indicates a Pat to Taproot script
+  "Check if given `script-pubkey` indicates a Pat to Taproot script
 structure:
    OP_1
    <32-byte witness-program>"
@@ -409,8 +409,8 @@ structure:
    (= 32 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun script-standard-p (script-pubkey &key network)
-  "If given script is standard, return a common name for the script type (:P2SH,
-:P2PKH, :P2WSH, etc) or T, otherwise return NIL. Additionally, if the address
+  "If given script is standard, return a common name for the script type (`:p2sh`,
+`:p2pkh`, `:p2wsh`, etc) or `t`, otherwise return `nil`. Additionally, if the address
 format is defined for that type of script, return a Bitcoin address for a given
 script as a second value."
   (let ((commands (script-commands script-pubkey)))
@@ -473,10 +473,10 @@ script as a second value."
 executable one (i.e. the current code path does not contain false
 conditions), or it is a branching command.
 
-For this purpose, OP_IF pushes its condition to CONDITIONS stack in
-script state (OP_NOTIF pushes an inverted condition), OP_ELSE inverts
-the top condition in CONDITIONS, while OP_ENDIF simply pops the top
-condition. For OP_ELSE/OP_ENDIF commands, empty CONDITIONS stack means
+For this purpose, `op_if` pushes its condition to `conditions` stack in
+script state (`op_notif` pushes an inverted condition), `op_else` inverts
+the top condition in `conditions`, while `op_endif` simply pops the top
+condition. For `op_else`/`op_endif` commands, empty `conditions` stack means
 that the branching construction is unbalanced.
 
 This follows the implementation of script interpreter in Bitcoin
@@ -494,9 +494,9 @@ Core."
 
 (defvar *trace-script-execution* nil
   "Dynamic variable to control printing the steps of script execution.
-If its value is not NIL, it will be used as a first argument to the
-FORMAT function for logging script steps (i.e. setting it to T will
-print the trace to *STANDARD-OUTPUT*, while setting it to a stream
+If its value is not `nil`, it will be used as a first argument to the
+`format` function for logging script steps (i.e. setting it to `t` will
+print the trace to `*standard-output*`, while setting it to a stream
 value will write the trace to that stream).")
 
 (defun print-script-execution-state (current-command state)
@@ -576,7 +576,7 @@ value will write the trace to that stream).")
       ;; Parse and execute the redeem-script.
       (with-input-from-byte-array (stream redeem-script-bytes)
         (let ((redeem-script (parse 'script stream)))
-          ;; Override the sigversion set in EXECUTE-SCRIPTS.
+          ;; Override the sigversion set in `execute-scripts`.
           (setf (@sigversion state) (script-sigversion redeem-script))
           (cond
             ;; P2SH-P2WPKH (P2WPKH nested in P2SH).
@@ -603,7 +603,7 @@ value will write the trace to that stream).")
   (let* ((witness (@witness state))
          (witness-length (length witness))
          (witness-stack (coerce (subseq witness 0 (1- witness-length)) 'list)))
-    ;; Execute WITNESS-STACK to push data items to stack. We don't
+    ;; Execute `witness-stack` to push data items to stack. We don't
     ;; care if returned value is non-false.
     (execute-script (apply #'script witness-stack) :state state)
     ;; Verify that SHA256(<witness-script>) is equal to
@@ -623,7 +623,7 @@ value will write the trace to that stream).")
 
 (defun script-sigversion (script)
   "For non-SegWit transactions, signature version is represented as
-constant :BASE, and for SegWit ones - :WITNESS-V<N>, where N is the
+constant `:base`, and for SegWit ones - `:witness-v<N>`, where N is the
 first op of the witness script pubkey."
   (if (segwit-p script)
       (let ((segwit-version (command-number (aref (script-commands script) 0))))
@@ -631,14 +631,14 @@ first op of the witness script pubkey."
       :base))
 
 (defun execute-scripts (script-sig script-pubkey &key state)
-  "Execute SCRIPT-SIG and SCRIPT-PUBKEY in succession, preserving the
+  "Execute `script-sig` and `script-pubkey` in succession, preserving the
 stack and performing the special rule detection (P2SH, SegWit)."
   (let ((state (or state (make-script-state))))
-    ;; Execute SCRIPT-SIG - it doen't have to leave the stack in
+    ;; Execute `script-sig` - it doen't have to leave the stack in
     ;; non-false state, so we ignore the value.
     (execute-script script-sig :state state)
     ;; This is correct for all types of scripts except P2SH. Will be
-    ;; overwritten in EXECUTE-P2SH.
+    ;; overwritten in `execute-p2sh`.
     (setf (@sigversion state) (script-sigversion script-pubkey))
     (cond
       ((p2sh-p script-pubkey)

--- a/core/transaction.lisp
+++ b/core/transaction.lisp
@@ -141,16 +141,16 @@ serialization including witness structures."
   (hex-encode (reverse (tx-hash tx))))
 
 (defun tx-output (tx index)
-  "Return INDEXth output of the given transaction."
+  "Return `index`th output of the given transaction."
   (aref (tx-outputs tx) index))
 
 (defun tx-input (tx index)
-  "Return INDEXth input of the given transaction."
+  "Return `index`th input of the given transaction."
   (aref (tx-inputs tx) index))
 
 (defun tx-witness (tx index)
-  "Return INDEXth witness of the given transaction if it is a SegWit
-transaction, otherwise return NIL."
+  "Return `index`th witness of the given transaction if it is a SegWit
+transaction, otherwise return `nil`."
   (when (tx-witnesses tx)
     (aref (tx-witnesses tx) index)))
 

--- a/net/message.lisp
+++ b/net/message.lisp
@@ -11,7 +11,7 @@
                 #:ascii-string-to-byte-array)
   (:import-from :usocket)
   ;; Messages and their field accessors are automatically exported by
-  ;; the DEFMESSAGE macro. Non-message structures and other utils are
+  ;; the `defmessage` macro. Non-message structures and other utils are
   ;; exported below.
   (:export
    #:packet
@@ -126,14 +126,14 @@
   "Hash is related to a data block.")
 
 (defconstant +iv-msg-filtered-block+ 3
-  "Hash of a block header; identical to MSG_BLOCK. Only to be used in
-getdata message. Indicates the reply should be a merkleblock message
-rather than a block message; this only works if a bloom filter has
+  "Hash of a block header; identical to `MSG_BLOCK`. Only to be used in
+`GETDATA` message. Indicates the reply should be a `MERKLEBLOCK` message
+rather than a `BLOCK` message; this only works if a bloom filter has
 been set.")
 
 (defconstant +iv-msg-cmpct-block+ 4
-  "Hash of a block header; identical to MSG_BLOCK. Only to be used in
-getdata message. Indicates the reply should be a cmpctblock
+  "Hash of a block header; identical to `MSG_BLOCK`. Only to be used in
+`GETDATA` message. Indicates the reply should be a `CMPCTBLOCK`
 message. See BIP-0152 for more info.")
 
 (defmethod serialize ((struct inventory-vector) stream)
@@ -189,12 +189,12 @@ message. See BIP-0152 for more info.")
 
            ;; Additional utils depending on OPTIONS values.
            ,@(when not-implemented
-               `(;; BP:SERIALIZE method for non-implemented messages
+               `(;; `bp:serialize` method for non-implemented messages
                  ;; should just return an error.
                  (defmethod serialize ((message ,name) stream)
                    (declare (ignore stream))
                    (error "~a serialization is not implemented." ,(string-upcase command)))
-                 ;; BP:PARSE method for non-implemented messages
+                 ;; `bp:parse` method for non-implemented messages
                  ;; should not fail - such messages will usually be
                  ;; silently ignored.
                  (defmethod parse ((message-class (eql ',name)) stream)
@@ -349,7 +349,7 @@ message. See BIP-0152 for more info.")
 (defmessage getheaders-message (:not-implemented t))
 
 
-;; BLOCK
+;; TX
 
 (defmessage tx-message ()
   tx)

--- a/net/node.lisp
+++ b/net/node.lisp
@@ -100,7 +100,7 @@
       (parse (message-type-from-command (packet-command packet)) stream))))
 
 (defun perform-handshake (node peer)
-  ;; Construct our VERSION message.
+  ;; Construct our `VERSION` message.
   (let ((version-message (make-version-message
                           :receiver-address (make-network-address
                                              :timestamp (get-universal-time)
@@ -119,14 +119,14 @@
                           :user-agent *user-agent*
                           :height 0
                           :relayp nil)))
-    ;; Send our VERSION message.
+    ;; Send our `VERSION` message.
     (send-message node peer version-message)
-    ;; Receive peer's VERSION message.
+    ;; Receive peer's `VERSION` message.
     (let ((peer-version-message (receive-message node peer)))
-      ;; Exchange VERACK messages.
+      ;; Exchange `VERACK` messages.
       (send-message node peer (make-verack-message))
       (assert (typep (receive-message node peer) 'verack-message))
-      ;; Populate PEER structure.
+      ;; Populate `peer` structure.
       (setf (peer-version peer) (version-message-version peer-version-message))
       (setf (peer-services peer) (version-message-services peer-version-message))
       (setf (peer-timestamp peer) (version-message-timestamp peer-version-message))
@@ -177,7 +177,7 @@ single peer via peer-2-peer gossip protocol."))
 ;;; Network interface implementation
 
 (defmethod connect-peer ((node simple-node) &key host port)
-  ;; Open a connection to the peer and construct a new PEER structure.
+  ;; Open a connection to the peer and construct a new `peer` structure.
   (let* ((host (or host "127.0.0.1"))
          (port (or port (ecase (node-network node)
                           (:mainnet +network-port+)
@@ -191,8 +191,8 @@ single peer via peer-2-peer gossip protocol."))
                       :local-host original-node-host
                       :local-port original-node-port))
          (peer (make-peer :host host :port port :connection connection)))
-    ;; Update node's HOST and PORT slots before handshake to be able
-    ;; to construct corret NETWORK-ADDRESS structs.
+    ;; Update node's `host` and `port` slots before handshake to be able
+    ;; to construct correct `network-address` structs.
     (setf (node-host node) (usocket:get-local-address connection))
     (setf (node-port node) (usocket:get-local-port connection))
     ;; Perform a handshake, but make sure the connection is closed if
@@ -202,7 +202,7 @@ single peer via peer-2-peer gossip protocol."))
       (error (e)
         (usocket:socket-close (peer-connection peer))
         (error e)))
-    ;; Only update node's HOST and PEER slots if successfully
+    ;; Only update node's `host` and `peer` slots if successfully
     ;; connected and shook hands.
     (setf (node-host node) original-node-host)
     (setf (node-port node) original-node-port)
@@ -266,10 +266,10 @@ single peer via peer-2-peer gossip protocol."))
   (:report
    (lambda (e s)
      (format s "Transaction ~a is not in mempool or relay set." (unknown-transaction-id e))))
-  (:documentation "NOTFOUND response to +IV-MSG-TX+ GETDATA message
+  (:documentation "`NOTFOUND` response to `GETDATA`/`MSG_TX` message
 means that the transaction that was requested is either unknown or is
 not present in mempool or relay-set, so this error is more precise
-than UNKNOWN-TRANSACTION-ERROR."))
+than `unknown-transaction-error`."))
 
 (defmethod chain-get-transaction ((node simple-node) id &key encoded errorp)
   (with-chain-supplier-normalization (id encoded errorp

--- a/tests/data.lisp
+++ b/tests/data.lisp
@@ -33,7 +33,7 @@
 
 (defclass test-chain-supplier (chain-supplier)
   ()
-  (:documentation "TEST-CHAIN-SUPPLIER retrieves chain data from a set
+  (:documentation "`test-chain-supplier` retrieves chain data from a set
 of hash tables defined above."))
 
 ;;; Implementation of chain supplier API for test supplier.
@@ -60,7 +60,7 @@ of hash tables defined above."))
 
 
 (defmacro add-test-block (name &body (height hash hex))
-  "Define a variable NAME storing test block index HEIGHT; add
+  "Define a variable `name` storing test block index `height`; add
 provided block data to the corresponding lookup structures."
   `(progn
      (eval-when (:load-toplevel)
@@ -72,7 +72,7 @@ provided block data to the corresponding lookup structures."
        (export ',name))))
 
 (defmacro add-test-transaction (name &body (hash hex))
-  "Define a variable NAME storing test transaction hash HASH; add
+  "Define a variable `name` storing test transaction hash `hash`; add
 provided transaction data to the corresponding lookup structures."
   `(progn
      (eval-when (:load-toplevel)

--- a/tests/encoding.lisp
+++ b/tests/encoding.lisp
@@ -12,20 +12,20 @@
 Protocol.")
 
 (def-suite base58-tests
-  :description "Tests for BASE58/BASE58-CHECK encoding."
+  :description "Tests for BASE58/BASE58CHECK encoding."
   :in encoding-tests)
 
 (in-suite base58-tests)
 
 (test base58-isomorphism
-  :description "Randomized test that verifies that the BASE58-ENCODE
-and BASE58-DECODE functions form an isomorphism."
+  :description "Randomized test that verifies that the `base58-encode`
+and `base58-decode` functions form an isomorphism."
   (for-all ((bytes (gen-buffer)))
     (is (equalp bytes (base58-decode (base58-encode bytes))))))
 
 (test base58check-isomorphism
   :description "Randomized test that verifies that the
-BASE58CHECK-ENCODE and BASE58CHECK-DECODE functions form an
+`base58check-encode` and `base58check-decode` functions form an
 isomorphism."
   (for-all ((bytes (gen-buffer)))
     (is (equalp bytes (base58check-decode (base58check-encode bytes))))))
@@ -38,7 +38,7 @@ isomorphism."
   (is (string= (base58-encode #(255)) "5Q")))
 
 (test base58check-corner-cases
-  :description "Corner cases for BASE58-CHECK encoding."
+  :description "Corner cases for BASE58CHECK encoding."
   (is (string= (base58check-encode #()) "3QJmnh"))
   (is (string= (base58check-encode #(0)) "1Wh4bh"))
   (is (string= (base58check-encode #(0 0 0 0)) "11114bdQda"))
@@ -49,7 +49,7 @@ isomorphism."
   (signals t (base58-decode "0"))) ;; bad character
 
 (test base58check-decode-errors
-  :description "Encoding bad BASE58-CHECK strings."
+  :description "Encoding bad BASE58CHECK strings."
   (signals base58check-no-checksum-error (base58check-decode ""))
   (signals base58check-bad-checksum-error (base58check-decode "1Wh4bm")))
 
@@ -74,14 +74,14 @@ isomorphism."
     (values bytes hrp encoding)))
 
 (defun segwit-version-opcode (number)
-  ;; TODO: maybe make this a more general utility in BP.CORE.SCRIPT.
+  ;; TODO: maybe make this a more general utility in `bp.core.script`.
   (if (<= 0 number 16)
       (intern (format nil "~a_~a" 'op number) :keyword)
       (error "Segwit version must be in between 0 and 16.")))
 
 (test bech32-isomorphism
-  :description "Randomized test that verifies that the BECH32-ENCODE
-and BECH32-DECODE functions form an isomorphism."
+  :description "Randomized test that verifies that the `bech32-encode`
+and `bech32-decode` functions form an isomorphism."
   (for-all ((bytes (gen-buffer)))
     (is (equalp bytes (bech32-assert-decode (bech32-encode "iso" bytes))))))
 
@@ -164,7 +164,7 @@ from BIP-0173 document."
 
 (test bech32m-isomorphism
   :description "Randomized test that verifies that Bech32m variants of
-the BECH32-ENCODE and BECH32-DECODE functions form an isomorphism."
+the `bech32-encode` and `bech32-decode` functions form an isomorphism."
   (for-all ((bytes (gen-buffer)))
     (is (equalp bytes (bech32m-assert-decode (bech32-encode "iso" bytes :bech32m-p t))))))
 


### PR DESCRIPTION
This comes from a personal belief that all documentation and/or comments should be in Markdown everywhere.