### PR TITLE
Updates and bug fixes for `crypto.secp256k1`

### DIFF
--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -47,7 +47,7 @@
 ;;;
 ;;; libsecp256k1 version:
 ;;;
-;;;     v0.7.1 (1a53f4961f337b4d166c25fce72ef0dc88806618)
+;;;     v0.8.0 (6e2c8bc4ecdc6e71dbe7a368f360d8d453ce435d)
 ;;;
 ;;;
 ;;; Comments for CFFI declarations are taken directly from the libsecp256k1
@@ -242,9 +242,6 @@
 ;; It is highly recommended to call secp256k1_selftest before using this context.
 ;;
 (defcvar "secp256k1_context_static" (:pointer (:struct secp256k1-context)))
-
-;; Deprecated alias for secp256k1_context_static.
-(defcvar "secp256k1_context_no_precomp" (:pointer (:struct secp256k1-context)))
 
 ;; Perform basic self tests (to be used in conjunction with secp256k1_context_static)
 ;;
@@ -446,6 +443,60 @@
   (ctx  (:pointer (:struct secp256k1-context)))
   (fun  :pointer)  ;; void (*fun)(const char* message, void* data)
   (data :pointer)) ;; void*
+
+;; A pointer to a function implementing SHA256's internal compression function.
+;;
+;; This function processes one or more contiguous 64-byte message blocks and
+;; updates the internal SHA256 state accordingly. The function is not responsible
+;; for counting consumed blocks or bytes, nor for performing padding.
+;;
+;; In/Out:  state:     pointer to eight 32-bit words representing the current internal state;
+;;                     the state is updated in place.
+;; In:      blocks64:  pointer to concatenation of n_blocks blocks, of 64 bytes each.
+;;                     no alignment guarantees are made for this pointer.
+;;          n_blocks:  number of contiguous 64-byte blocks to process.
+;;
+;; typedef void (*secp256k1_sha256_compression_function)(
+;;     uint32_t *state,
+;;     const unsigned char *blocks64,
+;;     size_t n_blocks
+;; );
+(defctype secp256k1-sha256-compression-function :pointer)
+
+;; Set a callback function to override the internal SHA256 compression function.
+;;
+;; This installs a callback to replace the built-in block-compression
+;; step used by the library's internal SHA256 implementation.
+;; The provided callback must exactly implement the effect of n_blocks
+;; repeated applications of the SHA256 compression function.
+;;
+;; This API exists to support environments that wish to route the
+;; SHA256 compression step through a hardware-accelerated or otherwise
+;; specialized implementation. It is NOT meant for replacing SHA256
+;; with a different hash function.
+;;
+;; Since auxiliary functions exposed by the library via a function
+;; pointer such as secp256k1_nonce_function_default do not take a
+;; context object, they will not use the callback when called directly
+;; from user code. (But they will use the callback when called from
+;; other library functions that do take a context object, e.g., when
+;; noncefp==NULL or noncefp==secp256k1_nonce_function_default is passed
+;; as an argument to secp256k1_ecdsa_sign.)
+;;
+;; Note: The provided function is tested against a set of known SHA256
+;; digests; invokes the context's illegal callback on any mismatch
+;; (which aborts by default), in order to catch basic misbehavior early.
+;; It takes well under 2.5 ms on a desktop machine.
+;; This is NOT a substitute for having proper test coverage of the
+;; supplied function outside this library.
+;;
+;; Args:    ctx:             pointer to a context object.
+;; In:      fn_compression:  pointer to a function implementing the compression function;
+;;                           passing NULL restores the default implementation.
+;;
+(defcfun "secp256k1_context_set_sha256_compression" :void
+  (ctx            (:pointer (:struct secp256k1-context)))
+  (fn-compression secp256k1-sha256-compression-function))
 
 ;; Parse a variable-length public key into the pubkey object.
 ;;
@@ -1907,15 +1958,6 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (keypair    (:pointer (:struct secp256k1-keypair)))
   (aux-rand32 (:pointer :unsigned-char)))
 
-;; Same as secp256k1_schnorrsig_sign32, but DEPRECATED. Will be removed in
-;; future versions.
-(defcfun "secp256k1_schnorrsig_sign" :int
-  (ctx        (:pointer (:struct secp256k1-context)))
-  (sig64      (:pointer :unsigned-char))
-  (msg32      (:pointer :unsigned-char))
-  (keypair    (:pointer (:struct secp256k1-keypair)))
-  (aux-rand32 (:pointer :unsigned-char)))
-
 ;; Create a Schnorr signature with a more flexible API.
 ;;
 ;; Same arguments as secp256k1_schnorrsig_sign except that it allows signing
@@ -2504,6 +2546,383 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (session      (:pointer (:struct secp256k1-musig-session)))
   (partial-sigs (:pointer (:pointer (:struct secp256k1-musig-partial-sig))))
   (n-sigs       :size))
+
+
+;;;-----------------------------------------------------------------------------
+;;; secp256k1_silentpayments.h
+;;;
+;;; This module provides an implementation for Silent Payments, as specified in
+;;; BIP352. This particularly involves the creation of input tweak data by
+;;; summing up secret or public keys and the derivation of a shared secret using
+;;; Elliptic Curve Diffie-Hellman. Combined are either:
+;;;   - spender's secret keys and recipient's public key (a * B, sender side)
+;;;   - spender's public keys and recipient's secret key (A * b, recipient side)
+;;; With this result, the necessary key material for ultimately creating/scanning
+;;; or spending Silent Payments outputs can be determined.
+;;;
+;;; Note that this module is _not_ a full implementation of BIP352, as it
+;;; inherently doesn't deal with higher-level concepts like addresses, output
+;;; script types or transactions. The intent is to provide a module for
+;;; abstracting away the elliptic-curve operations required for the protocol. For
+;;; any wallet software already using libsecp256k1, this API should provide all
+;;; the functions needed for a Silent Payments implementation without requiring
+;;; any further elliptic-curve operations from the wallet.
+;;;
+
+;; Maximum number of Silent Payments recipients per group (i.e.
+;; recipients sharing the same scan public key) as per BIP-352
+(defconstant +secp256k1-silentpayments-recipient-group-limit+ 2323)
+
+;; The data from a single recipient address
+;;
+;; This struct serves as an input argument to `silentpayments_sender_create_outputs`.
+;;
+;; `index` must be set to the position (starting with 0) of this recipient in the
+;; `recipients` array passed to `silentpayments_sender_create_outputs`. It is
+;; used to map the returned generated outputs back to the original recipient.
+;;
+;; Note:
+;; The spend public key named `spend_pubkey` may have been optionally tweaked with
+;; a label by the recipient. Whether `spend_pubkey` has actually been tagged with
+;; a label is irrelevant for the sender. As a documentation convention in this API,
+;; `unlabeled_spend_pubkey` is used to indicate when the unlabeled spend public key
+;; must be used.
+;;
+(defcstruct secp256k1-silentpayments-recipient
+  (scan-pubkey  (:struct secp256k1-pubkey))
+  (spend-pubkey (:struct secp256k1-pubkey))
+  (index        :size))
+
+;; Create Silent Payments outputs for recipient(s).
+;;
+;; Given a list of n secret keys a_1...a_n (one for each Silent Payments
+;; eligible input to spend), a serialized outpoint, and a list of recipients,
+;; create the taproot outputs. Inputs with conditional branches or multiple
+;; public keys are excluded from Silent Payments eligible inputs; see BIP352
+;; for more information.
+;;
+;; `outpoint_smallest36` refers to the smallest outpoint lexicographically
+;; from the transaction inputs (both Silent Payments eligible and non-eligible
+;; inputs). This value MUST be the smallest outpoint out of all of the
+;; transaction inputs, otherwise the recipient will be unable to find the
+;; payment. Determining the smallest outpoint from the list of transaction
+;; inputs is the responsibility of the caller. It is strongly recommended
+;; that implementations ensure they are doing this correctly by using the
+;; test vectors from BIP352.
+;;
+;; When creating more than one generated output, all of the generated outputs
+;; MUST be included in the final transaction. Dropping any of the generated
+;; outputs from the final transaction may make all or some of the outputs
+;; unfindable by the recipient.
+;;
+;; Returns: 1 if creation of outputs was successful.
+;;          0 on failure, i.e., when one of the following occurs:
+;;            - The size of any group (i.e. recipients sharing the same scan public key)
+;;              exceeds the protocol limit SECP256K1_SILENTPAYMENTS_RECIPIENT_GROUP_LIMIT.
+;;            - The sum of all input secret keys is 0.
+;;              (This occurs only with negligible probability if at least one of the
+;;              input secret keys is uniformly random and independent of all other keys.)
+;;            - An invalid output public key is created. (This can only happen for an
+;;              adversarially chosen recipient spend public key.)
+;;
+;; Args:                ctx: pointer to a context object
+;;                           (not secp256k1_context_static).
+;; Out:   generated_outputs: pointer to an array of pointers to xonly public keys,
+;;                           one per recipient.
+;;                           The outputs are ordered to match the original
+;;                           ordering of the recipient objects, i.e.,
+;;                           `generated_outputs[0]` is the generated output
+;;                           for the `secp256k1_silentpayments_recipient` object
+;;                           with index = 0.
+;; In:           recipients: pointer to an array of pointers to Silent Payments
+;;                           recipients, where each recipient is a scan public
+;;                           key, a spend public key, and an index indicating
+;;                           its position in the original ordering. This function
+;;                           may reorder the pointers to the recipient objects
+;;                           within the array, i.e., after the call (including on
+;;                           failure), the index fields of the recipient objects
+;;                           may no longer correspond to the positions in the
+;;                           array. Multiple recipient objects with the same scan
+;;                           public key and/or same spend public key can be passed
+;;                           if they carry different indices.
+;;             n_recipients: the size of the recipients array.
+;;      outpoint_smallest36: serialized (36-byte) smallest outpoint
+;;                           (lexicographically) from the transaction inputs
+;;                 keypairs: pointer to an array of pointers to taproot
+;;                           keypair inputs (can be NULL if no secret keys
+;;                           of taproot inputs are used)
+;;               n_keypairs: the size of the keypairs array.
+;;                  seckeys: pointer to an array of pointers to 32-byte
+;;                           secret keys of non-taproot inputs (can be NULL
+;;                           if no secret keys of non-taproot inputs are
+;;                           used)
+;;                n_seckeys: the size of the seckeys array.
+;;
+(defcfun "secp256k1_silentpayments_sender_create_outputs" :int
+  (ctx                 (:pointer (:struct secp256k1-context)))
+  (generated-outputs   (:pointer (:pointer (:struct secp256k1-xonly-pubkey))))
+  (recipients          (:pointer (:pointer (:struct secp256k1-silentpayments-recipient))))
+  (n-recipients        :size)
+  (outpoint-smallest36 (:pointer :unsigned-char))
+  (keypairs            (:pointer (:pointer (:struct secp256k1-keypair))))
+  (n-keypairs          :size)
+  (seckeys             (:pointer (:pointer :unsigned-char)))
+  (n-seckeys           :size))
+
+;; Opaque data structure that holds a Silent Payments label.
+;;
+;; Guaranteed to be 68 bytes in size. Serialized and parsed with
+;; `secp256k1_silentpayments_recipient_label_serialize` and
+;; `secp256k1_silentpayments_recipient_label_parse`.
+;;
+(defcstruct secp256k1-silentpayments-label
+  (data :unsigned-char :count 68))
+
+;; Parse a Silent Payments label.
+;;
+;; Returns: 1 when the label could be parsed, 0 otherwise.
+;; Args:    ctx: pointer to a context object
+;; Out:   label: pointer to a label object
+;; In:     in33: pointer to the 33-byte label to be parsed
+;;
+(defcfun "secp256k1_silentpayments_recipient_label_parse" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (label (:pointer (:struct secp256k1-silentpayments-label)))
+  (in33  (:pointer :unsigned-char)))
+
+;; Serialize a Silent Payments label
+;;
+;; Returns: 1 always
+;; Args:    ctx: pointer to a context object
+;; Out:   out33: pointer to a 33-byte array to store the serialized label
+;; In:    label: pointer to the label
+;;
+(defcfun "secp256k1_silentpayments_recipient_label_serialize" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (out33 (:pointer :unsigned-char))
+  (label (:pointer (:struct secp256k1-silentpayments-label))))
+
+;; Create Silent Payments label tweak and label.
+;;
+;; Given a recipient's 32 byte scan key and a label integer m, calculate the
+;; corresponding label tweak and label:
+;;
+;;     label_tweak = hash(scan_key || m)
+;;           label = label_tweak * G
+;;
+;; Returns: 1 if label tweak and label creation was successful.
+;;          0 if scan_key32 is invalid or the hash output label_tweak32 is
+;;            not a valid scalar (negligible probability per hash evaluation).
+;;
+;; WARNING: Creating a large number of labels may significantly degrade
+;; scanning performance in certain Silent Payments wallet implementations,
+;; such as light clients. The scanning function provided in this module,
+;; which is designed for full nodes, performs consistently even with hundreds
+;; of thousands of labels. Other implementations may not share this property
+;; or may be unable to use it due to lacking full transaction data.
+;;
+;; To maximize wallet interoperability, it is recommended to create only
+;; the change label (m = 0) and avoid distributing labeled addresses.
+;;
+;; Args:                ctx: pointer to a context object
+;;                           (not secp256k1_context_static)
+;; Out:               label: pointer to the resulting label
+;;            label_tweak32: pointer to the 32 byte label tweak
+;; In:           scan_key32: pointer to the recipient's 32 byte scan key
+;;                        m: integer for the m-th label (0 is used for change outputs)
+;;
+(defcfun "secp256k1_silentpayments_recipient_label_create" :int
+  (ctx           (:pointer (:struct secp256k1-context)))
+  (label         (:pointer (:struct secp256k1-silentpayments-label)))
+  (label-tweak32 (:pointer :unsigned-char))
+  (scan-key32    (:pointer :unsigned-char))
+  (m             :uint32))
+
+;; Create Silent Payments labeled spend public key.
+;;
+;; Given a recipient's spend public key and a label, calculate the
+;; corresponding labeled spend public key:
+;;
+;;     labeled_spend_pubkey = unlabeled_spend_pubkey + label
+;;
+;; The result is used by the recipient to create a Silent Payments address,
+;; consisting of the serialized and concatenated scan public key and
+;; (labeled) spend public key.
+;;
+;; Returns: 1 if labeled spend public key creation was successful.
+;;          0 if spend pubkey and label sum to zero (negligible probability for
+;;            labels created according to BIP352).
+;;
+;; Args:                    ctx: pointer to a context object
+;; Out:    labeled_spend_pubkey: pointer to the resulting labeled spend public key
+;; In:   unlabeled_spend_pubkey: pointer to the recipient's unlabeled spend public key
+;;                        label: pointer to the recipient's label
+;;
+(defcfun "secp256k1_silentpayments_recipient_create_labeled_spend_pubkey" :int
+  (ctx                    (:pointer (:struct secp256k1-context)))
+  (labeled-spend-pubkey   (:pointer (:struct secp256k1-pubkey)))
+  (unlabeled-spend-pubkey (:pointer (:struct secp256k1-pubkey)))
+  (label                  (:pointer (:struct secp256k1-silentpayments-label))))
+
+;; Opaque data structure that holds Silent Payments prevouts summary data.
+;;
+;; The exact representation of data inside is implementation defined and not
+;; guaranteed to be portable between different platforms or versions. It is
+;; however guaranteed to be 101 bytes in size, and can be safely copied/moved.
+;; This structure does not contain secret data. It can be created with
+;; `secp256k1_silentpayments_recipient_prevouts_summary_create`.
+;;
+(defcstruct secp256k1-silentpayments-prevouts-summary
+  (data :unsigned-char :count 101))
+
+;; Compute Silent Payments prevouts summary from prevout public keys and transaction
+;; inputs.
+;;
+;; Given a list of n public keys A_1...A_n (one for each Silent Payments
+;; eligible input to spend) and a serialized outpoint_smallest36, create a
+;; `prevouts_summary` object. This object summarizes the prevout data from the
+;; transaction inputs needed for scanning.
+;;
+;; `outpoint_smallest36` refers to the smallest outpoint lexicographically
+;; from the transaction inputs (both Silent Payments eligible and non-eligible
+;; inputs). This value MUST be the smallest outpoint out of all of the
+;; transaction inputs, otherwise the recipient will be unable to find the
+;; payment.
+;;
+;; The public keys have to be passed in via two different parameter pairs, one
+;; for regular and one for x-only public keys, in order to avoid the need of
+;; users converting to a common public key format before calling this function.
+;; The resulting data can be used for scanning on the recipient side.
+;;
+;; Returns: 1 if prevouts summary creation was successful.
+;;          0 if the transaction is not a Silent Payments transaction.
+;;
+;; Args:                 ctx: pointer to a context object
+;; Out:     prevouts_summary: pointer to prevouts_summary object containing the
+;;                            summed public key and input_hash.
+;; In:   outpoint_smallest36: serialized smallest outpoint (lexicographically)
+;;                            from the transaction inputs
+;;             xonly_pubkeys: pointer to an array of pointers to taproot
+;;                            x-only public keys (can be NULL if no taproot
+;;                            inputs are used)
+;;           n_xonly_pubkeys: the size of the xonly_pubkeys array.
+;;                   pubkeys: pointer to an array of pointers to non-taproot
+;;                            public keys (can be NULL if no non-taproot
+;;                            inputs are used)
+;;                 n_pubkeys: the size of the pubkeys array.
+;;
+(defcfun "secp256k1_silentpayments_recipient_prevouts_summary_create" :int
+  (ctx                 (:pointer (:struct secp256k1-context)))
+  (prevouts-summary    (:pointer (:struct secp256k1-silentpayments-prevouts-summary)))
+  (outpoint-smallest36 (:pointer :unsigned-char))
+  (xonly-pubkeys       (:pointer (:pointer (:struct secp256k1-xonly-pubkey))))
+  (n-xonly-pubkeys     :size)
+  (pubkeys             (:pointer (:pointer (:struct secp256k1-pubkey))))
+  (n-pubkeys           :size))
+
+;; Type of callback function for label lookups
+;;
+;; A function of this type will be used to retrieve the label tweak for a given
+;; label during scanning. A typical implementation will perform a lookup in a
+;; key-value store called the "label cache".
+;;
+;; For creating the label cache data,
+;; `secp256k1_silentpayments_recipient_label_create` and
+;; `secp256k1_silentpayments_recipient_label_serialize` can be used.
+;;
+;; Returns: pointer to the 32-byte label tweak if there is a match.
+;;          NULL pointer if there is no match.
+;;
+;; In:         label: pointer to the serialized 33-byte label to check
+;;                    (computed during scanning)
+;;     label_context: pointer to the recipient's label cache.
+;;
+;; typedef const unsigned char* (*secp256k1_silentpayments_label_lookup)(
+;;     const unsigned char* label33,
+;;     const void* label_context
+;; );
+(defctype secp256k1-silentpayments-label-lookup :pointer)
+
+;; Found outputs struct
+;;
+;; Struct for holding a found output along with data needed to spend it later.
+;;
+;;           output: the x-only public key for the taproot output
+;;            tweak: the 32-byte tweak needed to spend the output
+;; found_with_label: boolean value to indicate if the output was sent to a
+;;                   labeled address. If true, label will be set to a valid value.
+;;            label: the label used. If found_with_label = false, this is set to
+;;                   an invalid value.
+;;
+(defcstruct secp256k1-silentpayments-found-output
+  (output           (:struct secp256k1-xonly-pubkey))
+  (tweak            :unsigned-char :count 32)
+  (found-with-label :int)
+  (label            (:struct secp256k1-silentpayments-label)))
+
+;; Scan for Silent Payments transaction outputs.
+;;
+;; Given a prevouts_summary object, a recipient's 32 byte scan key and spend public key,
+;; and the relevant transaction outputs, scan for outputs belonging to
+;; the recipient and return the tweak(s) needed for spending the output(s). An
+;; optional label_lookup callback function and label_context can be passed if
+;; the recipient uses labels. This allows for checking if a label exists in
+;; the recipients label cache and retrieving the label tweak during scanning.
+;;
+;; If used, the `label_lookup` function must return a pointer to a 32-byte label
+;; tweak if the label is found, or NULL otherwise. The returned pointer must remain
+;; valid until the next call to `label_lookup` or until the function returns,
+;; whichever comes first. It is not retained beyond that.
+;;
+;; For creating the label cache, `secp256k1_silentpayments_recipient_label_create`
+;; and `secp256k1_silentpayments_recipient_label_serialize` can be used.
+;;
+;; Note:
+;; Scanning is bounded by SECP256K1_SILENTPAYMENTS_RECIPIENT_GROUP_LIMIT and may
+;; miss outputs if a transaction contains more outputs for a single scan public
+;; key group than this limit.
+;;
+;; Returns: 1 if output scanning was successful.
+;;          0 if the transaction is not a Silent Payments transaction,
+;;            or if the arguments are invalid.
+;;
+;; Args:                   ctx: pointer to a context object
+;; Out:          found_outputs: pointer to an array of pointers to found
+;;                              output objects. The found outputs array MUST
+;;                              have the same length as the tx_outputs array.
+;;             n_found_outputs: pointer to an integer indicating the final
+;;                              size of the found outputs array. This number
+;;                              represents the number of outputs found while
+;;                              scanning (0 if none are found). Can't be larger than
+;;                              SECP256K1_SILENTPAYMENTS_RECIPIENT_GROUP_LIMIT.
+;; In:              tx_outputs: pointer to the transaction's x-only public key outputs,
+;;                              in their original transaction (vout) order
+;;                n_tx_outputs: the size of the tx_outputs array.
+;;                  scan_key32: pointer to the recipient's 32 byte scan key. The scan
+;;                              key is valid if it passes secp256k1_ec_seckey_verify
+;;            prevouts_summary: pointer to the transaction prevouts summary data (see
+;;                              `secp256k1_silentpayments_recipient_prevouts_summary_create`).
+;;      unlabeled_spend_pubkey: pointer to the recipient's unlabeled spend public key
+;;                label_lookup: pointer to a callback function for looking up
+;;                              a label value. This function takes a serialized 33-byte
+;;                              label as an argument and returns a pointer to the
+;;                              32-byte label tweak if the label exists, otherwise
+;;                              returns a NULL pointer (NULL if labels are not
+;;                              used)
+;;               label_context: pointer to a label context object (NULL if
+;;                              labels are not used or context is not needed)
+;;
+(defcfun "secp256k1_silentpayments_recipient_scan_outputs" :int
+  (ctx                    (:pointer (:struct secp256k1-context)))
+  (found-outputs          (:pointer (:pointer (:struct secp256k1-silentpayments-found-output))))
+  (n-found-outputs        (:pointer :uint32))
+  (tx-outputs             (:pointer (:pointer (:struct secp256k1-xonly-pubkey))))
+  (n-tx-outputs           :size)
+  (scan-key32             (:pointer :unsigned-char))
+  (prevouts-summary       (:pointer (:struct secp256k1-silentpayments-prevouts-summary)))
+  (unlabeled-spend-pubkey (:pointer (:struct secp256k1-pubkey)))
+  (label-lookup           secp256k1-silentpayments-label-lookup)
+  (label-context          :pointer)) ;; const void*
 
 
 ;;;-----------------------------------------------------------------------------

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -47,7 +47,7 @@
 ;;;
 ;;; libsecp256k1 version:
 ;;;
-;;;     v0.2.0 (21ffe4b22a9683cf24ae0763359e401d1284cc7a)
+;;;     v0.7.1 (1a53f4961f337b4d166c25fce72ef0dc88806618)
 ;;;
 ;;;
 ;;; Comments for CFFI declarations are taken directly from the libsecp256k1
@@ -137,19 +137,6 @@
 ;; you do not need any locking for the other calls), or use a read-write lock.
 ;;
 (defcstruct secp256k1-context)
-
-;; Opaque data structure that holds rewritable "scratch space"
-;;
-;; The purpose of this structure is to replace dynamic memory allocations,
-;; because we target architectures where this may not be available. It is
-;; essentially a resizable (within specified parameters) block of bytes,
-;; which is initially created either by memory allocation or TODO as a pointer
-;; into some fixed rewritable space.
-;;
-;; Unlike the context object, this cannot safely be shared between threads
-;; without additional synchronization logic.
-;;
-(defcstruct secp256k1-scratch-space)
 
 ;; Opaque data structure that holds a parsed and valid public key.
 ;;
@@ -455,27 +442,6 @@
   (fun  :pointer)  ;; void (*fun)(const char* message, void* data)
   (data :pointer)) ;; void*
 
-;; Create a secp256k1 scratch space object.
-;;
-;; Returns: a newly created scratch space.
-;; Args: ctx:  an existing context object.
-;; In:   size: amount of memory to be available as scratch space. Some extra
-;;             (<100 bytes) will be allocated for extra accounting.
-;;
-(defcfun "secp256k1_scratch_space_create" :pointer
-  (ctx  (:pointer (:struct secp256k1-context)))
-  (size size))
-
-;; Destroy a secp256k1 scratch space.
-;;
-;; The pointer may not be used afterwards.
-;; Args:       ctx: a secp256k1 context object.
-;;         scratch: space to destroy
-;;
-(defcfun "secp256k1_scratch_space_destroy" :void
-  (ctx     (:pointer (:struct secp256k1-context)))
-  (scratch (:pointer (:struct secp256k1-scratch-space))))
-
 ;; Parse a variable-length public key into the pubkey object.
 ;;
 ;; Returns: 1 if the public key was fully valid.
@@ -555,6 +521,19 @@
   (ctx     (:pointer (:struct secp256k1-context)))
   (pubkey1 (:pointer (:struct secp256k1-pubkey)))
   (pubkey2 (:pointer (:struct secp256k1-pubkey))))
+
+;; Sort public keys using lexicographic (of compressed serialization) order
+;;
+;; Returns: 0 if the arguments are invalid. 1 otherwise.
+;;
+;; Args:     ctx: pointer to a context object
+;; In:   pubkeys: array of pointers to pubkeys to sort
+;;     n_pubkeys: number of elements in the pubkeys array
+;;
+(defcfun "secp256k1_ec_pubkey_sort" :int
+  (ctx       (:pointer (:struct secp256k1-context)))
+  (pubkeys   (:pointer (:pointer (:struct secp256k1-pubkey))))
+  (n-pubkeys size))
 
 ;; Parse an ECDSA signature in compact (64 bytes) format.
 ;;
@@ -973,19 +952,6 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
     (unless (zerop (secp256k1-ec-seckey-negate *secp256k1-context* cseckey))
       (bytes-from-foreign seckey cseckey 32))))
 
-;; Same as secp256k1_ec_seckey_negate, but DEPRECATED. Will be removed in
-;; future versions.
-(defcfun "secp256k1_ec_privkey_negate" :int
-  (ctx    (:pointer (:struct secp256k1-context)))
-  (seckey (:pointer :unsigned-char)))
-
-(defun ec-privkey-negate (seckey)
-  (with-foreign-objects
-      ((cseckey :unsigned-char 32))
-    (bytes-to-foreign seckey cseckey 32)
-    (secp256k1-ec-privkey-negate *secp256k1-context* cseckey)
-    (bytes-from-foreign seckey cseckey 32)))
-
 ;; Negates a public key in place.
 ;;
 ;; Returns: 1 always
@@ -1023,13 +989,6 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (seckey (:pointer :unsigned-char))
   (tweak  (:pointer :unsigned-char)))
 
-;; Same as secp256k1_ec_seckey_tweak_add, but DEPRECATED. Will be removed in
-;; future versions.
-(defcfun "secp256k1_ec_privkey_tweak_add" :int
-  (ctx    (:pointer (:struct secp256k1-context)))
-  (seckey (:pointer :unsigned-char))
-  (tweak  (:pointer :unsigned-char)))
-
 ;; Tweak a public key by adding tweak times the generator to it.
 ;;
 ;; Returns: 0 if the arguments are invalid or the resulting public key would be
@@ -1062,13 +1021,6 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;                 is negligible (around 1 in 2^128).
 ;;
 (defcfun "secp256k1_ec_seckey_tweak_mul" :int
-  (ctx    (:pointer (:struct secp256k1-context)))
-  (seckey (:pointer :unsigned-char))
-  (tweak  (:pointer :unsigned-char)))
-
-;; Same as secp256k1_ec_seckey_tweak_mul, but DEPRECATED. Will be removed in
-;; future versions.
-(defcfun "secp256k1_ec_privkey_tweak_mul" :int
   (ctx    (:pointer (:struct secp256k1-context)))
   (seckey (:pointer :unsigned-char))
   (tweak  (:pointer :unsigned-char)))
@@ -1197,6 +1149,197 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (seckey (:pointer :unsigned-char))
   (hashfp secp256k1-ecdh-hash-function)
   (data   :pointer)) ;; void*
+
+
+;;;-----------------------------------------------------------------------------
+;;; secp256k1_ellswift.h
+;;;
+;;; This module provides an implementation of ElligatorSwift as well as a
+;;; version of x-only ECDH using it (including compatibility with BIP324).
+;;;
+;;; ElligatorSwift is described in https://eprint.iacr.org/2022/759 by
+;;; Chavez-Saab, Rodriguez-Henriquez, and Tibouchi. It permits encoding
+;;; uniformly chosen public keys as 64-byte arrays which are indistinguishable
+;;; from uniformly random arrays.
+;;;
+;;; Let f be the function from pairs of field elements to point X coordinates,
+;;; defined as follows (all operations modulo p = 2^256 - 2^32 - 977)
+;;; f(u,t):
+;;; - Let C = 0xa2d2ba93507f1df233770c2a797962cc61f6d15da14ecd47d8d27ae1cd5f852,
+;;;   a square root of -3.
+;;; - If u=0, set u=1 instead.
+;;; - If t=0, set t=1 instead.
+;;; - If u^3 + t^2 + 7 = 0, multiply t by 2.
+;;; - Let X = (u^3 + 7 - t^2) / (2 * t)
+;;; - Let Y = (X + t) / (C * u)
+;;; - Return the first in [u + 4 * Y^2, (-X/Y - u) / 2, (X/Y - u) / 2] that is an
+;;;   X coordinate on the curve (at least one of them is, for any u and t).
+;;;
+;;; Then an ElligatorSwift encoding of x consists of the 32-byte big-endian
+;;; encodings of field elements u and t concatenated, where f(u,t) = x.
+;;; The encoding algorithm is described in the paper, and effectively picks a
+;;; uniformly random pair (u,t) among those which encode x.
+;;;
+;;; If the Y coordinate is relevant, it is given the same parity as t.
+;;;
+;;; Changes w.r.t. the paper:
+;;; - The u=0, t=0, and u^3+t^2+7=0 conditions result in decoding to the point
+;;;   at infinity in the paper. Here they are remapped to finite points.
+;;; - The paper uses an additional encoding bit for the parity of y. Here the
+;;;   parity of t is used (negating t does not affect the decoded x coordinate,
+;;;   so this is possible).
+;;;
+;;; For mathematical background about the scheme, see the doc/ellswift.md file.
+;;;
+
+;; A pointer to a function used by secp256k1_ellswift_xdh to hash the shared X
+;; coordinate along with the encoded public keys to a uniform shared secret.
+;;
+;; Returns: 1 if a shared secret was successfully computed.
+;;          0 will cause secp256k1_ellswift_xdh to fail and return 0.
+;;          Other return values are not allowed, and the behaviour of
+;;          secp256k1_ellswift_xdh is undefined for other return values.
+;; Out:     output:     pointer to an array to be filled by the function
+;; In:      x32:        pointer to the 32-byte serialized X coordinate
+;;                      of the resulting shared point (will not be NULL)
+;;          ell_a64:    pointer to the 64-byte encoded public key of party A
+;;                      (will not be NULL)
+;;          ell_b64:    pointer to the 64-byte encoded public key of party B
+;;                      (will not be NULL)
+;;          data:       arbitrary data pointer that is passed through
+;;
+;; typedef int (*secp256k1_ellswift_xdh_hash_function)(
+;;     unsigned char *output,
+;;     const unsigned char *x32,
+;;     const unsigned char *ell_a64,
+;;     const unsigned char *ell_b64,
+;;     void *data
+;; );
+(defctype secp256k1-ellswift-xdh-hash-function :pointer)
+
+;; An implementation of an secp256k1_ellswift_xdh_hash_function which uses
+;; SHA256(prefix64 || ell_a64 || ell_b64 || x32), where prefix64 is the 64-byte
+;; array pointed to by data.
+;;
+(defcvar "secp256k1_ellswift_xdh_hash_function_prefix"
+    secp256k1-ellswift-xdh-hash-function)
+
+;; An implementation of an secp256k1_ellswift_xdh_hash_function compatible with
+;; BIP324. It returns H_tag(ell_a64 || ell_b64 || x32), where H_tag is the
+;; BIP340 tagged hash function with tag "bip324_ellswift_xonly_ecdh". Equivalent
+;; to secp256k1_ellswift_xdh_hash_function_prefix with prefix64 set to
+;; SHA256("bip324_ellswift_xonly_ecdh")||SHA256("bip324_ellswift_xonly_ecdh").
+;; The data argument is ignored.
+;;
+(defcvar "secp256k1_ellswift_xdh_hash_function_bip324"
+    secp256k1-ellswift-xdh-hash-function)
+
+;; Construct a 64-byte ElligatorSwift encoding of a given pubkey.
+;;
+;; Returns: 1 always.
+;; Args:    ctx:        pointer to a context object
+;; Out:     ell64:      pointer to a 64-byte array to be filled
+;; In:      pubkey:     pointer to a secp256k1_pubkey containing an
+;;                      initialized public key
+;;          rnd32:      pointer to 32 bytes of randomness
+;;
+;; It is recommended that rnd32 consists of 32 uniformly random bytes, not
+;; known to any adversary trying to detect whether public keys are being
+;; encoded, though 16 bytes of randomness (padded to an array of 32 bytes,
+;; e.g., with zeros) suffice to make the result indistinguishable from
+;; uniform. The randomness in rnd32 must not be a deterministic function of
+;; the pubkey (it can be derived from the private key, though).
+;;
+;; It is not guaranteed that the computed encoding is stable across versions
+;; of the library, even if all arguments to this function (including rnd32)
+;; are the same.
+;;
+;; This function runs in variable time.
+;;
+(defcfun "secp256k1_ellswift_encode" :int
+  (ctx    (:pointer (:struct secp256k1-context)))
+  (ell64  (:pointer :unsigned-char))
+  (pubkey (:pointer (:struct secp256k1-pubkey)))
+  (rnd32  (:pointer :unsigned-char)))
+
+;; Decode a 64-bytes ElligatorSwift encoded public key.
+;;
+;; Returns: always 1
+;; Args:    ctx:        pointer to a context object
+;; Out:     pubkey:     pointer to a secp256k1_pubkey that will be filled
+;; In:      ell64:      pointer to a 64-byte array to decode
+;;
+;; This function runs in variable time.
+;;
+(defcfun "secp256k1_ellswift_decode" :int
+  (ctx    (:pointer (:struct secp256k1-context)))
+  (pubkey (:pointer (:struct secp256k1-pubkey)))
+  (ell64  (:pointer :unsigned-char)))
+
+;; Compute an ElligatorSwift public key for a secret key.
+;;
+;; Returns: 1: secret was valid, public key was stored.
+;;          0: secret was invalid, try again.
+;; Args:    ctx:        pointer to a context object (not secp256k1_context_static)
+;; Out:     ell64:      pointer to a 64-byte array to receive the ElligatorSwift
+;;                      public key
+;; In:      seckey32:   pointer to a 32-byte secret key
+;;          auxrnd32:   (optional) pointer to 32 bytes of randomness
+;;
+;; Constant time in seckey and auxrnd32, but not in the resulting public key.
+;;
+;; It is recommended that auxrnd32 contains 32 uniformly random bytes, though
+;; it is optional (and does result in encodings that are indistinguishable from
+;; uniform even without any auxrnd32). It differs from the (mandatory) rnd32
+;; argument to secp256k1_ellswift_encode in this regard.
+;;
+;; This function can be used instead of calling secp256k1_ec_pubkey_create
+;; followed by secp256k1_ellswift_encode. It is safer, as it uses the secret
+;; key as entropy for the encoding (supplemented with auxrnd32, if provided).
+;;
+;; Like secp256k1_ellswift_encode, this function does not guarantee that the
+;; computed encoding is stable across versions of the library, even if all
+;; arguments (including auxrnd32) are the same.
+;;
+(defcfun "secp256k1_ellswift_create" :int
+  (ctx      (:pointer (:struct secp256k1-context)))
+  (ell64    (:pointer :unsigned-char))
+  (seckey32 (:pointer :unsigned-char))
+  (auxrnd32 (:pointer :unsigned-char)))
+
+;; Given a private key, and ElligatorSwift public keys sent in both directions,
+;; compute a shared secret using x-only Elliptic Curve Diffie-Hellman (ECDH).
+;;
+;; Returns: 1: shared secret was successfully computed
+;;          0: secret was invalid or hashfp returned 0
+;; Args:    ctx:       pointer to a context object.
+;; Out:     output:    pointer to an array to be filled by hashfp.
+;; In:      ell_a64:   pointer to the 64-byte encoded public key of party A
+;;                     (will not be NULL)
+;;          ell_b64:   pointer to the 64-byte encoded public key of party B
+;;                     (will not be NULL)
+;;          seckey32:  pointer to our 32-byte secret key
+;;          party:     boolean indicating which party we are: zero if we are
+;;                     party A, non-zero if we are party B. seckey32 must be
+;;                     the private key corresponding to that party's ell_?64.
+;;                     This correspondence is not checked.
+;;          hashfp:    pointer to a hash function.
+;;          data:      arbitrary data pointer passed through to hashfp.
+;;
+;; Constant time in seckey32.
+;;
+;; This function is more efficient than decoding the public keys, and performing
+;; ECDH on them.
+;;
+(defcfun "secp256k1_ellswift_xdh" :int
+  (ctx      (:pointer (:struct secp256k1-context)))
+  (output   (:pointer :unsigned-char))
+  (ell-a64  (:pointer :unsigned-char))
+  (ell-b64  (:pointer :unsigned-char))
+  (seckey32 (:pointer :unsigned-char))
+  (party    :int)
+  (hashfp   secp256k1-ellswift-xdh-hash-function)
+  (data     :pointer)) ;; void*
 
 
 ;;;-----------------------------------------------------------------------------
@@ -1797,6 +1940,557 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (msg    (:pointer :unsigned-char))
   (msglen size)
   (pubkey (:pointer (:struct secp256k1-xonly-pubkey))))
+
+
+;;;-----------------------------------------------------------------------------
+;;; secp256k1_musig.h
+;;;
+;;; This module implements BIP 327 "MuSig2 for BIP340-compatible
+;;; Multi-Signatures"
+;;; (https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)
+;;; v1.0.0. You can find an example demonstrating the musig module in
+;;; examples/musig.c.
+;;;
+;;; The module also supports BIP 341 ("Taproot") public key tweaking.
+;;;
+;;; It is recommended to read the documentation in this include file carefully.
+;;; Further notes on API usage can be found in doc/musig.md
+;;;
+;;; Since the first version of MuSig is essentially replaced by MuSig2, we use
+;;; MuSig, musig and MuSig2 synonymously unless noted otherwise.
+;;;
+
+;; Opaque data structures
+;;
+;; The exact representation of data inside the opaque data structures is
+;; implementation defined and not guaranteed to be portable between different
+;; platforms or versions. With the exception of `secp256k1_musig_secnonce`, the
+;; data structures can be safely copied/moved. If you need to convert to a
+;; format suitable for storage, transmission, or comparison, use the
+;; corresponding serialization and parsing functions.
+;;
+
+;; Opaque data structure that caches information about public key aggregation.
+;;
+;; Guaranteed to be 197 bytes in size. No serialization and parsing functions
+;; (yet).
+;;
+(defcstruct secp256k1-musig-keyagg-cache
+  (data :unsigned-char :count 197))
+
+;; Opaque data structure that holds a signer's _secret_ nonce.
+;;
+;; Guaranteed to be 132 bytes in size.
+;;
+;; WARNING: This structure MUST NOT be copied or read or written to directly. A
+;; signer who is online throughout the whole process and can keep this
+;; structure in memory can use the provided API functions for a safe standard
+;; workflow.
+;;
+;; Copying this data structure can result in nonce reuse which will leak the
+;; secret signing key.
+;;
+(defcstruct secp256k1-musig-secnonce
+  (data :unsigned-char :count 132))
+
+;; Opaque data structure that holds a signer's public nonce.
+;;
+;; Guaranteed to be 132 bytes in size. Serialized and parsed with
+;; `musig_pubnonce_serialize` and `musig_pubnonce_parse`.
+;;
+(defcstruct secp256k1-musig-pubnonce
+  (data :unsigned-char :count 132))
+
+;; Opaque data structure that holds an aggregate public nonce.
+;;
+;; Guaranteed to be 132 bytes in size. Serialized and parsed with
+;; `musig_aggnonce_serialize` and `musig_aggnonce_parse`.
+;;
+(defcstruct secp256k1-musig-aggnonce
+  (data :unsigned-char :count 132))
+
+;; Opaque data structure that holds a MuSig session.
+;;
+;; This structure is not required to be kept secret for the signing protocol to
+;; be secure. Guaranteed to be 133 bytes in size. No serialization and parsing
+;; functions (yet).
+;;
+(defcstruct secp256k1-musig-session
+  (data :unsigned-char :count 133))
+
+;; Opaque data structure that holds a partial MuSig signature.
+;;
+;; Guaranteed to be 36 bytes in size. Serialized and parsed with
+;; `musig_partial_sig_serialize` and `musig_partial_sig_parse`.
+;;
+(defcstruct secp256k1-musig-partial-sig
+  (data :unsigned-char :count 36))
+
+;; Parse a signer's public nonce.
+;;
+;; Returns: 1 when the nonce could be parsed, 0 otherwise.
+;; Args:    ctx: pointer to a context object
+;; Out:   nonce: pointer to a nonce object
+;; In:     in66: pointer to the 66-byte nonce to be parsed
+;;
+(defcfun "secp256k1_musig_pubnonce_parse" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (nonce (:pointer (:struct secp256k1-musig-pubnonce)))
+  (in66  (:pointer :unsigned-char)))
+
+;; Serialize a signer's public nonce
+;;
+;; Returns: 1 always
+;; Args:    ctx: pointer to a context object
+;; Out:   out66: pointer to a 66-byte array to store the serialized nonce
+;; In:    nonce: pointer to the nonce
+;;
+(defcfun "secp256k1_musig_pubnonce_serialize" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (out66 (:pointer :unsigned-char))
+  (nonce (:pointer (:struct secp256k1-musig-pubnonce))))
+
+;; Parse an aggregate public nonce.
+;;
+;; Returns: 1 when the nonce could be parsed, 0 otherwise.
+;; Args:    ctx: pointer to a context object
+;; Out:   nonce: pointer to a nonce object
+;; In:     in66: pointer to the 66-byte nonce to be parsed
+;;
+(defcfun "secp256k1_musig_aggnonce_parse" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (nonce (:pointer (:struct secp256k1-musig-aggnonce)))
+  (in66  (:pointer :unsigned-char)))
+
+;; Serialize an aggregate public nonce
+;;
+;; Returns: 1 always
+;; Args:    ctx: pointer to a context object
+;; Out:   out66: pointer to a 66-byte array to store the serialized nonce
+;; In:    nonce: pointer to the nonce
+;;
+(defcfun "secp256k1_musig_aggnonce_serialize" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (out66 (:pointer :unsigned-char))
+  (nonce (:pointer (:struct secp256k1-musig-aggnonce))))
+
+;; Parse a MuSig partial signature.
+;;
+;; Returns: 1 when the signature could be parsed, 0 otherwise.
+;; Args:    ctx: pointer to a context object
+;; Out:     sig: pointer to a signature object
+;; In:     in32: pointer to the 32-byte signature to be parsed
+;;
+(defcfun "secp256k1_musig_partial_sig_parse" :int
+  (ctx  (:pointer (:struct secp256k1-context)))
+  (sig  (:pointer (:struct secp256k1-musig-partial-sig)))
+  (in32 (:pointer :unsigned-char)))
+
+;; Serialize a MuSig partial signature
+;;
+;; Returns: 1 always
+;; Args:    ctx: pointer to a context object
+;; Out:   out32: pointer to a 32-byte array to store the serialized signature
+;; In:      sig: pointer to the signature
+;;
+(defcfun "secp256k1_musig_partial_sig_serialize" :int
+  (ctx   (:pointer (:struct secp256k1-context)))
+  (out32 (:pointer :unsigned-char))
+  (sig   (:pointer (:struct secp256k1-musig-partial-sig))))
+
+;; Computes an aggregate public key and uses it to initialize a keyagg_cache
+;;
+;; Different orders of `pubkeys` result in different `agg_pk`s.
+;;
+;; Before aggregating, the pubkeys can be sorted with `secp256k1_ec_pubkey_sort`
+;; which ensures the same `agg_pk` result for the same multiset of pubkeys.
+;; This is useful to do before `pubkey_agg`, such that the order of pubkeys
+;; does not affect the aggregate public key.
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:        ctx: pointer to a context object
+;; Out:      agg_pk: the MuSig-aggregated x-only public key. If you do not need it,
+;;                   this arg can be NULL.
+;;     keyagg_cache: if non-NULL, pointer to a musig_keyagg_cache struct that
+;;                   is required for signing (or observing the signing session
+;;                   and verifying partial signatures).
+;;  In:     pubkeys: input array of pointers to public keys to aggregate. The order
+;;                   is important; a different order will result in a different
+;;                   aggregate public key.
+;;        n_pubkeys: length of pubkeys array. Must be greater than 0.
+;;
+(defcfun "secp256k1_musig_pubkey_agg" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (agg-pk       (:pointer (:struct secp256k1-xonly-pubkey)))
+  (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (pubkeys      (:pointer (:pointer (:struct secp256k1-pubkey))))
+  (n-pubkeys    size))
+
+;; Obtain the aggregate public key from a keyagg_cache.
+;;
+;; This is only useful if you need the non-xonly public key, in particular for
+;; plain (non-xonly) tweaking or batch-verifying multiple key aggregations
+;; (not implemented).
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:        ctx: pointer to a context object
+;; Out:      agg_pk: the MuSig-aggregated public key.
+;; In: keyagg_cache: pointer to a `musig_keyagg_cache` struct initialized by
+;;                   `musig_pubkey_agg`
+;;
+(defcfun "secp256k1_musig_pubkey_get" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (agg-pk       (:pointer (:struct secp256k1-pubkey)))
+  (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache))))
+
+;; Apply plain "EC" tweaking to a public key in a given keyagg_cache by adding
+;; the generator multiplied with `tweak32` to it. This is useful for deriving
+;; child keys from an aggregate public key via BIP 32 where `tweak32` is set to
+;; a hash as defined in BIP 32.
+;;
+;; Callers are responsible for deriving `tweak32` in a way that does not reduce
+;; the security of MuSig (for example, by following BIP 32).
+;;
+;; The tweaking method is the same as `secp256k1_ec_pubkey_tweak_add`. So after
+;; the following pseudocode buf and buf2 have identical contents (absent
+;; earlier failures).
+;;
+;; secp256k1_musig_pubkey_agg(..., keyagg_cache, pubkeys, ...)
+;; secp256k1_musig_pubkey_get(..., agg_pk, keyagg_cache)
+;; secp256k1_musig_pubkey_ec_tweak_add(..., output_pk, tweak32, keyagg_cache)
+;; secp256k1_ec_pubkey_serialize(..., buf, ..., output_pk, ...)
+;; secp256k1_ec_pubkey_tweak_add(..., agg_pk, tweak32)
+;; secp256k1_ec_pubkey_serialize(..., buf2, ..., agg_pk, ...)
+;;
+;; This function is required if you want to _sign_ for a tweaked aggregate key.
+;; If you are only computing a public key but not intending to create a
+;; signature for it, use `secp256k1_ec_pubkey_tweak_add` instead.
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:            ctx: pointer to a context object
+;; Out:   output_pubkey: pointer to a public key to store the result. Will be set
+;;                       to an invalid value if this function returns 0. If you
+;;                       do not need it, this arg can be NULL.
+;; In/Out: keyagg_cache: pointer to a `musig_keyagg_cache` struct initialized by
+;;                      `musig_pubkey_agg`
+;; In:          tweak32: pointer to a 32-byte tweak. The tweak is valid if it passes
+;;                       `secp256k1_ec_seckey_verify` and is not equal to the
+;;                       secret key corresponding to the public key represented
+;;                       by keyagg_cache or its negation. For uniformly random
+;;                       32-byte arrays the chance of being invalid is
+;;                       negligible (around 1 in 2^128).
+;;
+(defcfun "secp256k1_musig_pubkey_ec_tweak_add" :int
+  (ctx           (:pointer (:struct secp256k1-context)))
+  (output-pubkey (:pointer (:struct secp256k1-pubkey)))
+  (keyagg-cache  (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (tweak32       (:pointer :unsigned-char)))
+
+;; Apply x-only tweaking to a public key in a given keyagg_cache by adding the
+;; generator multiplied with `tweak32` to it. This is useful for creating
+;; Taproot outputs where `tweak32` is set to a TapTweak hash as defined in BIP
+;; 341.
+;;
+;; Callers are responsible for deriving `tweak32` in a way that does not reduce
+;; the security of MuSig (for example, by following Taproot BIP 341).
+;;
+;; The tweaking method is the same as `secp256k1_xonly_pubkey_tweak_add`. So in
+;; the following pseudocode xonly_pubkey_tweak_add_check (absent earlier
+;; failures) returns 1.
+;;
+;; secp256k1_musig_pubkey_agg(..., agg_pk, keyagg_cache, pubkeys, ...)
+;; secp256k1_musig_pubkey_xonly_tweak_add(..., output_pk, keyagg_cache, tweak32)
+;; secp256k1_xonly_pubkey_serialize(..., buf, output_pk)
+;; secp256k1_xonly_pubkey_tweak_add_check(..., buf, ..., agg_pk, tweak32)
+;;
+;; This function is required if you want to _sign_ for a tweaked aggregate key.
+;; If you are only computing a public key but not intending to create a
+;; signature for it, use `secp256k1_xonly_pubkey_tweak_add` instead.
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:            ctx: pointer to a context object
+;; Out:   output_pubkey: pointer to a public key to store the result. Will be set
+;;                       to an invalid value if this function returns 0. If you
+;;                       do not need it, this arg can be NULL.
+;; In/Out: keyagg_cache: pointer to a `musig_keyagg_cache` struct initialized by
+;;                      `musig_pubkey_agg`
+;; In:          tweak32: pointer to a 32-byte tweak. The tweak is valid if it passes
+;;                       `secp256k1_ec_seckey_verify` and is not equal to the
+;;                       secret key corresponding to the public key represented
+;;                       by keyagg_cache or its negation. For uniformly random
+;;                       32-byte arrays the chance of being invalid is
+;;                       negligible (around 1 in 2^128).
+;;
+(defcfun "secp256k1_musig_pubkey_xonly_tweak_add" :int
+  (ctx           (:pointer (:struct secp256k1-context)))
+  (output-pubkey (:pointer (:struct secp256k1-pubkey)))
+  (keyagg-cache  (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (tweak32       (:pointer :unsigned-char)))
+
+;; Starts a signing session by generating a nonce
+;;
+;; This function outputs a secret nonce that will be required for signing and a
+;; corresponding public nonce that is intended to be sent to other signers.
+;;
+;; MuSig differs from regular Schnorr signing in that implementers _must_ take
+;; special care to not reuse a nonce. This can be ensured by following these rules:
+;;
+;; 1. Each call to this function must have a UNIQUE session_secrand32 that must
+;;    NOT BE REUSED in subsequent calls to this function and must be KEPT
+;;    SECRET (even from other signers).
+;; 2. If you already know the seckey, message or aggregate public key
+;;    cache, they can be optionally provided to derive the nonce and increase
+;;    misuse-resistance. The extra_input32 argument can be used to provide
+;;    additional data that does not repeat in normal scenarios, such as the
+;;    current time.
+;; 3. Avoid copying (or serializing) the secnonce. This reduces the possibility
+;;    that it is used more than once for signing.
+;;
+;; If you don't have access to good randomness for session_secrand32, but you
+;; have access to a non-repeating counter, then see
+;; secp256k1_musig_nonce_gen_counter.
+;;
+;; Remember that nonce reuse will leak the secret key!
+;; Note that using the same seckey for multiple MuSig sessions is fine.
+;;
+;; Returns: 0 if the arguments are invalid and 1 otherwise
+;; Args:         ctx: pointer to a context object (not secp256k1_context_static)
+;; Out:     secnonce: pointer to a structure to store the secret nonce
+;;          pubnonce: pointer to a structure to store the public nonce
+;; In/Out:
+;; session_secrand32: a 32-byte session_secrand32 as explained above. Must be unique to this
+;;                    call to secp256k1_musig_nonce_gen and must be uniformly
+;;                    random. If the function call is successful, the
+;;                    session_secrand32 buffer is invalidated to prevent reuse.
+;; In:
+;;            seckey: the 32-byte secret key that will later be used for signing, if
+;;                    already known (can be NULL)
+;;            pubkey: public key of the signer creating the nonce. The secnonce
+;;                    output of this function cannot be used to sign for any
+;;                    other public key. While the public key should correspond
+;;                    to the provided seckey, a mismatch will not cause the
+;;                    function to return 0.
+;;             msg32: the 32-byte message that will later be signed, if already known
+;;                    (can be NULL)
+;;      keyagg_cache: pointer to the keyagg_cache that was used to create the aggregate
+;;                    (and potentially tweaked) public key if already known
+;;                    (can be NULL)
+;;     extra_input32: an optional 32-byte array that is input to the nonce
+;;                    derivation function (can be NULL)
+;;
+(defcfun "secp256k1_musig_nonce_gen" :int
+  (ctx               (:pointer (:struct secp256k1-context)))
+  (secnonce          (:pointer (:struct secp256k1-musig-secnonce)))
+  (pubnonce          (:pointer (:struct secp256k1-musig-pubnonce)))
+  (session-secrand32 (:pointer :unsigned-char))
+  (seckey            (:pointer :unsigned-char))
+  (pubkey            (:pointer (:struct secp256k1-pubkey)))
+  (msg32             (:pointer :unsigned-char))
+  (keyagg-cache      (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (extra-input32     (:pointer :unsigned-char)))
+
+;; Alternative way to generate a nonce and start a signing session
+;;
+;; This function outputs a secret nonce that will be required for signing and a
+;; corresponding public nonce that is intended to be sent to other signers.
+;;
+;; This function differs from `secp256k1_musig_nonce_gen` by accepting a
+;; non-repeating counter value instead of a secret random value. This requires
+;; that a secret key is provided to `secp256k1_musig_nonce_gen_counter`
+;; (through the keypair argument), as opposed to `secp256k1_musig_nonce_gen`
+;; where the seckey argument is optional.
+;;
+;; MuSig differs from regular Schnorr signing in that implementers _must_ take
+;; special care to not reuse a nonce. This can be ensured by following these rules:
+;;
+;; 1. The nonrepeating_cnt argument must be a counter value that never repeats,
+;;    i.e., you must never call `secp256k1_musig_nonce_gen_counter` twice with
+;;    the same keypair and nonrepeating_cnt value. For example, this implies
+;;    that if the same keypair is used with `secp256k1_musig_nonce_gen_counter`
+;;    on multiple devices, none of the devices should have the same counter
+;;    value as any other device.
+;; 2. If the seckey, message or aggregate public key cache is already available
+;;    at this stage, any of these can be optionally provided, in which case
+;;    they will be used in the derivation of the nonce and increase
+;;    misuse-resistance. The extra_input32 argument can be used to provide
+;;    additional data that does not repeat in normal scenarios, such as the
+;;    current time.
+;; 3. Avoid copying (or serializing) the secnonce. This reduces the possibility
+;;    that it is used more than once for signing.
+;;
+;; Remember that nonce reuse will leak the secret key!
+;; Note that using the same keypair for multiple MuSig sessions is fine.
+;;
+;; Returns: 0 if the arguments are invalid and 1 otherwise
+;; Args:         ctx: pointer to a context object (not secp256k1_context_static)
+;; Out:     secnonce: pointer to a structure to store the secret nonce
+;;          pubnonce: pointer to a structure to store the public nonce
+;; In:
+;;  nonrepeating_cnt: the value of a counter as explained above. Must be
+;;                    unique to this call to secp256k1_musig_nonce_gen.
+;;           keypair: keypair of the signer creating the nonce. The secnonce
+;;                    output of this function cannot be used to sign for any
+;;                    other keypair.
+;;             msg32: the 32-byte message that will later be signed, if already known
+;;                    (can be NULL)
+;;      keyagg_cache: pointer to the keyagg_cache that was used to create the aggregate
+;;                    (and potentially tweaked) public key if already known
+;;                    (can be NULL)
+;;     extra_input32: an optional 32-byte array that is input to the nonce
+;;                    derivation function (can be NULL)
+;;
+(defcfun "secp256k1_musig_nonce_gen_counter" :int
+  (ctx              (:pointer (:struct secp256k1-context)))
+  (secnonce         (:pointer (:struct secp256k1-musig-secnonce)))
+  (pubnonce         (:pointer (:struct secp256k1-musig-pubnonce)))
+  (nonrepeating-cnt :uint64)
+  (keypair          (:pointer (:struct secp256k1-keypair)))
+  (msg32            (:pointer :unsigned-char))
+  (keyagg-cache     (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (extra-input32    (:pointer :unsigned-char)))
+
+;; Aggregates the nonces of all signers into a single nonce
+;;
+;; This can be done by an untrusted party to reduce the communication
+;; between signers. Instead of everyone sending nonces to everyone else, there
+;; can be one party receiving all nonces, aggregating the nonces with this
+;; function and then sending only the aggregate nonce back to the signers.
+;;
+;; If the aggregator does not compute the aggregate nonce correctly, the final
+;; signature will be invalid.
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:           ctx: pointer to a context object
+;; Out:       aggnonce: pointer to an aggregate public nonce object for
+;;                      musig_nonce_process
+;; In:       pubnonces: array of pointers to public nonces sent by the
+;;                      signers
+;;         n_pubnonces: number of elements in the pubnonces array. Must be
+;;                      greater than 0.
+;;
+(defcfun "secp256k1_musig_nonce_agg" :int
+  (ctx         (:pointer (:struct secp256k1-context)))
+  (aggnonce    (:pointer (:struct secp256k1-musig-aggnonce)))
+  (pubnonces   (:pointer (:pointer (:struct secp256k1-musig-pubnonce))))
+  (n-pubnonces size))
+
+;; Takes the aggregate nonce and creates a session that is required for signing
+;; and verification of partial signatures.
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise
+;; Args:          ctx: pointer to a context object
+;; Out:       session: pointer to a struct to store the session
+;; In:       aggnonce: pointer to an aggregate public nonce object that is the
+;;                     output of musig_nonce_agg
+;;             msg32:  the 32-byte message to sign
+;;      keyagg_cache:  pointer to the keyagg_cache that was used to create the
+;;                     aggregate (and potentially tweaked) pubkey
+;;
+(defcfun "secp256k1_musig_nonce_process" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (session      (:pointer (:struct secp256k1-musig-session)))
+  (aggnonce     (:pointer (:struct secp256k1-musig-aggnonce)))
+  (msg32        (:pointer :unsigned-char))
+  (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache))))
+
+;; Produces a partial signature
+;;
+;; This function overwrites the given secnonce with zeros and will abort if given a
+;; secnonce that is all zeros. This is a best effort attempt to protect against nonce
+;; reuse. However, this is of course easily defeated if the secnonce has been
+;; copied (or serialized). Remember that nonce reuse will leak the secret key!
+;;
+;; For signing to succeed, the secnonce provided to this function must have
+;; been generated for the provided keypair. This means that when signing for a
+;; keypair consisting of a seckey and pubkey, the secnonce must have been
+;; created by calling musig_nonce_gen with that pubkey. Otherwise, the
+;; illegal_callback is called.
+;;
+;; This function does not verify the output partial signature, deviating from
+;; the BIP 327 specification. It is recommended to verify the output partial
+;; signature with `secp256k1_musig_partial_sig_verify` to prevent random or
+;; adversarially provoked computation errors.
+;;
+;; Returns: 0 if the arguments are invalid or the provided secnonce has already
+;;          been used for signing, 1 otherwise
+;; Args:         ctx: pointer to a context object
+;; Out:  partial_sig: pointer to struct to store the partial signature
+;; In/Out:  secnonce: pointer to the secnonce struct created in
+;;                    musig_nonce_gen that has been never used in a
+;;                    partial_sign call before and has been created for the
+;;                    keypair
+;; In:       keypair: pointer to keypair to sign the message with
+;;      keyagg_cache: pointer to the keyagg_cache that was output when the
+;;                    aggregate public key for this session
+;;           session: pointer to the session that was created with
+;;                    musig_nonce_process
+;;
+(defcfun "secp256k1_musig_partial_sign" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (partial-sig  (:pointer (:struct secp256k1-musig-partial-sig)))
+  (secnonce     (:pointer (:struct secp256k1-musig-secnonce)))
+  (keypair      (:pointer (:struct secp256k1-keypair)))
+  (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (session      (:pointer (:struct secp256k1-musig-session))))
+
+;; Verifies an individual signer's partial signature
+;;
+;; The signature is verified for a specific signing session. In order to avoid
+;; accidentally verifying a signature from a different or non-existing signing
+;; session, you must ensure the following:
+;;   1. The `keyagg_cache` argument is identical to the one used to create the
+;;      `session` with `musig_nonce_process`.
+;;   2. The `pubkey` argument must be identical to the one sent by the signer
+;;      before aggregating it with `musig_pubkey_agg` to create the
+;;      `keyagg_cache`.
+;;   3. The `pubnonce` argument must be identical to the one sent by the signer
+;;      before aggregating it with `musig_nonce_agg` and using the result to
+;;      create the `session` with `musig_nonce_process`.
+;;
+;; It is not required to call this function in regular MuSig sessions, because
+;; if any partial signature does not verify, the final signature will not
+;; verify either, so the problem will be caught. However, this function
+;; provides the ability to identify which specific partial signature fails
+;; verification.
+;;
+;; Returns: 0 if the arguments are invalid or the partial signature does not
+;;          verify, 1 otherwise
+;; Args         ctx: pointer to a context object
+;; In:  partial_sig: pointer to partial signature to verify, sent by
+;;                   the signer associated with `pubnonce` and `pubkey`
+;;         pubnonce: public nonce of the signer in the signing session
+;;           pubkey: public key of the signer in the signing session
+;;     keyagg_cache: pointer to the keyagg_cache that was output when the
+;;                   aggregate public key for this signing session
+;;          session: pointer to the session that was created with
+;;                   `musig_nonce_process`
+;;
+(defcfun "secp256k1_musig_partial_sig_verify" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (partial-sig  (:pointer (:struct secp256k1-musig-partial-sig)))
+  (pubnonce     (:pointer (:struct secp256k1-musig-pubnonce)))
+  (pubkey       (:pointer (:struct secp256k1-pubkey)))
+  (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache)))
+  (session      (:pointer (:struct secp256k1-musig-session))))
+
+;; Aggregates partial signatures
+;;
+;; Returns: 0 if the arguments are invalid, 1 otherwise (which does NOT mean
+;;          the resulting signature verifies).
+;; Args:         ctx: pointer to a context object
+;; Out:        sig64: complete (but possibly invalid) Schnorr signature
+;; In:       session: pointer to the session that was created with
+;;                    musig_nonce_process
+;;      partial_sigs: array of pointers to partial signatures to aggregate
+;;            n_sigs: number of elements in the partial_sigs array. Must be
+;;                    greater than 0.
+;;
+(defcfun "secp256k1_musig_partial_sig_agg" :int
+  (ctx          (:pointer (:struct secp256k1-context)))
+  (sig64        (:pointer :unsigned-char))
+  (session      (:pointer (:struct secp256k1-musig-session)))
+  (partial-sigs (:pointer (:pointer (:struct secp256k1-musig-partial-sig))))
+  (n-sigs       size))
 
 
 ;;;-----------------------------------------------------------------------------

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -153,7 +153,7 @@
 (defcstruct secp256k1-pubkey
   (data :unsigned-char :count 64))
 
-;; Opaque data structured that holds a parsed ECDSA signature.
+;; Opaque data structure that holds a parsed ECDSA signature.
 ;;
 ;; The exact representation of data inside is implementation defined and not
 ;; guaranteed to be portable between different platforms or versions. It is
@@ -178,8 +178,8 @@
 ;;                     This will almost always be 0, but different attempt values
 ;;                     are required to result in a different nonce.
 ;;
-;; Except for test cases, this function should compute some cryptographic hash
-;; of the message, the algorithm, the key and the attempt.
+;; Except for test cases, this function should compute some cryptographic hash of
+;; the message, the algorithm, the key and the attempt.
 ;;
 ;; typedef int (*secp256k1_nonce_function)(
 ;;     unsigned char *nonce32,
@@ -223,7 +223,7 @@
 
 (defconstant +secp256k1-ec-uncompressed+ +secp256k1-flags-type-compression+)
 
-;; Prefix byte used to tag various encoded curvepoints for specific purposes.
+;; Prefix byte used to tag various encoded curvepoints for specific purposes
 (defconstant +secp256k1-tag-pubkey-even+         #x02)
 (defconstant +secp256k1-tag-pubkey-odd+          #x03)
 (defconstant +secp256k1-tag-pubkey-uncompressed+ #x04)
@@ -256,7 +256,7 @@
 ;; secp256k1_context_create (or secp256k1_context_preallocated_create), which will
 ;; take care of performing the self tests.
 ;;
-;; If the tests fail, this function will call the default error handler to abort the
+;; If the tests fail, this function will call the default error callback to abort the
 ;; program (see secp256k1_context_set_error_callback).
 ;;
 (defcfun "secp256k1_selftest" :void)
@@ -268,7 +268,7 @@
 ;; memory allocation entirely, see secp256k1_context_static and the functions in
 ;; secp256k1_preallocated.h.
 ;;
-;; Returns: a newly created context object.
+;; Returns: pointer to a newly created context object.
 ;; In:      flags: Always set to SECP256K1_CONTEXT_NONE (see below).
 ;;
 ;; The only valid non-deprecated flag in recent library versions is
@@ -298,8 +298,11 @@
 ;; called at most once for every call of this function. If you need to avoid dynamic
 ;; memory allocation entirely, see the functions in secp256k1_preallocated.h.
 ;;
-;; Returns: a newly created context object.
-;; Args:    ctx: an existing context to copy
+;; Cloning secp256k1_context_static is not possible, and should not be emulated by
+;; the caller (e.g., using memcpy). Create a new context instead.
+;;
+;; Returns: pointer to a newly created context object.
+;; Args:    ctx: pointer to a context to copy (not secp256k1_context_static).
 ;;
 (defcfun "secp256k1_context_clone" (:pointer (:struct secp256k1-context))
   (ctx (:pointer (:struct secp256k1-context))))
@@ -314,8 +317,9 @@
 ;; behaviour is undefined. In that case, secp256k1_context_preallocated_destroy must
 ;; be used instead.
 ;;
-;; Args:   ctx: an existing context to destroy, constructed using
+;; Args:   ctx: pointer to a context to destroy, constructed using
 ;;              secp256k1_context_create or secp256k1_context_clone
+;;              (i.e., not secp256k1_context_static).
 ;;
 (defcfun "secp256k1_context_destroy" :void
   (ctx (:pointer (:struct secp256k1-context))))
@@ -325,10 +329,10 @@
 
 ;; Randomizes the context to provide enhanced protection against side-channel leakage.
 ;;
-;; Returns: 1: randomization successful (or called on copy of secp256k1_context_static)
+;; Returns: 1: randomization successful
 ;;          0: error
-;; Args:    ctx:       pointer to a context object.
-;; In:      seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
+;; Args:    ctx:       pointer to a context object (not secp256k1_context_static).
+;; In:      seed32:    pointer to a 32-byte random seed (NULL resets to initial state).
 ;;
 ;; While secp256k1 code is written and tested to be constant-time no matter what
 ;; secret values are, it is possible that a compiler may output code which is not,
@@ -343,21 +347,17 @@
 ;; functions that perform computations involving secret keys, e.g., signing and
 ;; public key generation. It is possible to call this function more than once on
 ;; the same context, and doing so before every few computations involving secret
-;; keys is recommended as a defense-in-depth measure.
+;; keys is recommended as a defense-in-depth measure. Randomization of the static
+;; context secp256k1_context_static is not supported.
 ;;
 ;; Currently, the random seed is mainly used for blinding multiplications of a
 ;; secret scalar with the elliptic curve base point. Multiplications of this
 ;; kind are performed by exactly those API functions which are documented to
-;; require a context that is not the secp256k1_context_static. As a rule of thumb,
+;; require a context that is not secp256k1_context_static. As a rule of thumb,
 ;; these are all functions which take a secret key (or a keypair) as an input.
 ;; A notable exception to that rule is the ECDH module, which relies on a different
 ;; kind of elliptic curve point multiplication and thus does not benefit from
 ;; enhanced protection against side-channel leakage currently.
-;;
-;; It is safe call this function on a copy of secp256k1_context_static in writable
-;; memory (e.g., obtained via secp256k1_context_clone). In that case, this
-;; function is guaranteed to return 1, but the call will have no effect because
-;; the static context (or a copy thereof) is not meant to be randomized.
 ;;
 (defcfun "secp256k1_context_randomize" :int
   (ctx    (:pointer (:struct secp256k1-context)))
@@ -379,36 +379,38 @@
 ;; an API call. It will only trigger for violations that are mentioned
 ;; explicitly in the header.
 ;;
-;; The philosophy is that these shouldn't be dealt with through a
-;; specific return value, as calling code should not have branches to deal with
-;; the case that this code itself is broken.
+;; The philosophy is that these shouldn't be dealt with through a specific
+;; return value, as calling code should not have branches to deal with the case
+;; that this code itself is broken.
 ;;
 ;; On the other hand, during debug stage, one would want to be informed about
-;; such mistakes, and the default (crashing) may be inadvisable.
-;; When this callback is triggered, the API function called is guaranteed not
-;; to cause a crash, though its return value and output arguments are
-;; undefined.
+;; such mistakes, and the default (crashing) may be inadvisable. Should this
+;; callback return instead of crashing, the return value and output arguments
+;; of the API function call are undefined. Moreover, the same API call may
+;; trigger the callback again in this case.
 ;;
-;; When this function has not been called (or called with fn==NULL), then the
-;; default handler will be used. The library provides a default handler which
-;; writes the message to stderr and calls abort. This default handler can be
+;; When this function has not been called (or called with fun==NULL), then the
+;; default callback will be used. The library provides a default callback which
+;; writes the message to stderr and calls abort. This default callback can be
 ;; replaced at link time if the preprocessor macro
 ;; USE_EXTERNAL_DEFAULT_CALLBACKS is defined, which is the case if the build
-;; has been configured with --enable-external-default-callbacks. Then the
+;; has been configured with --enable-external-default-callbacks (GNU Autotools) or
+;; -DSECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS=ON (CMake). Then the
 ;; following two symbols must be provided to link against:
-;;  - void secp256k1_default_illegal_callback_fn(const char* message, void* data);
-;;  - void secp256k1_default_error_callback_fn(const char* message, void* data);
-;; The library can call these default handlers even before a proper callback data
+;;  - void secp256k1_default_illegal_callback_fn(const char *message, void *data);
+;;  - void secp256k1_default_error_callback_fn(const char *message, void *data);
+;; The library may call a default callback even before a proper callback data
 ;; pointer could have been set using secp256k1_context_set_illegal_callback or
 ;; secp256k1_context_set_error_callback, e.g., when the creation of a context
-;; fails. In this case, the corresponding default handler will be called with
+;; fails. In this case, the corresponding default callback will be called with
 ;; the data pointer argument set to NULL.
 ;;
-;; Args: ctx:  an existing context object.
-;; In:   fun:  a pointer to a function to call when an illegal argument is
+;; Args: ctx:  pointer to a context object.
+;; In:   fun:  pointer to a function to call when an illegal argument is
 ;;             passed to the API, taking a message and an opaque pointer.
-;;             (NULL restores the default handler.)
-;;       data: the opaque pointer to pass to fun above, must be NULL for the default handler.
+;;             (NULL restores the default callback.)
+;;       data: the opaque pointer to pass to fun above, must be NULL for the
+;;             default callback.
 ;;
 ;; See also secp256k1_context_set_error_callback.
 ;;
@@ -424,18 +426,19 @@
 ;; to abort the program.
 ;;
 ;; This can only trigger in case of a hardware failure, miscompilation,
-;; memory corruption, serious bug in the library, or other error would can
-;; otherwise result in undefined behaviour. It will not trigger due to mere
+;; memory corruption, serious bug in the library, or other error that would
+;; result in undefined behaviour. It will not trigger due to mere
 ;; incorrect usage of the API (see secp256k1_context_set_illegal_callback
 ;; for that). After this callback returns, anything may happen, including
 ;; crashing.
 ;;
-;; Args: ctx:  an existing context object.
-;; In:   fun:  a pointer to a function to call when an internal error occurs,
+;; Args: ctx:  pointer to a context object.
+;; In:   fun:  pointer to a function to call when an internal error occurs,
 ;;             taking a message and an opaque pointer (NULL restores the
-;;             default handler, see secp256k1_context_set_illegal_callback
+;;             default callback, see secp256k1_context_set_illegal_callback
 ;;             for details).
-;;       data: the opaque pointer to pass to fun above, must be NULL for the default handler.
+;;       data: the opaque pointer to pass to fun above, must be NULL for the
+;;             default callback.
 ;;
 ;; See also secp256k1_context_set_illegal_callback.
 ;;
@@ -502,7 +505,7 @@
 ;;
 ;; Returns: 1 if the public key was fully valid.
 ;;          0 if the public key could not be parsed or is invalid.
-;; Args: ctx:      a secp256k1 context object.
+;; Args: ctx:      pointer to a context object.
 ;; Out:  pubkey:   pointer to a pubkey object. If 1 is returned, it is set to a
 ;;                 parsed version of input. If not, its value is undefined.
 ;; In:   input:    pointer to a serialized public key
@@ -531,14 +534,14 @@
 ;; Serialize a pubkey object into a serialized byte sequence.
 ;;
 ;; Returns: 1 always.
-;; Args:   ctx:        a secp256k1 context object.
-;; Out:    output:     a pointer to a 65-byte (if compressed==0) or 33-byte (if
+;; Args:   ctx:        pointer to a context object.
+;; Out:    output:     pointer to a 65-byte (if compressed==0) or 33-byte (if
 ;;                     compressed==1) byte array to place the serialized key
 ;;                     in.
-;; In/Out: outputlen:  a pointer to an integer which is initially set to the
+;; In/Out: outputlen:  pointer to an integer which is initially set to the
 ;;                     size of output, and is overwritten with the written
 ;;                     size.
-;; In:     pubkey:     a pointer to a secp256k1_pubkey containing an
+;; In:     pubkey:     pointer to a secp256k1_pubkey containing an
 ;;                     initialized public key.
 ;;         flags:      SECP256K1_EC_COMPRESSED if serialization should be in
 ;;                     compressed format, otherwise SECP256K1_EC_UNCOMPRESSED.
@@ -569,7 +572,7 @@
 ;; Returns: <0 if the first public key is less than the second
 ;;          >0 if the first public key is greater than the second
 ;;          0 if the two public keys are equal
-;; Args: ctx:      a secp256k1 context object.
+;; Args: ctx:      pointer to a context object
 ;; In:   pubkey1:  first public key to compare
 ;;       pubkey2:  second public key to compare
 ;;
@@ -594,9 +597,9 @@
 ;; Parse an ECDSA signature in compact (64 bytes) format.
 ;;
 ;; Returns: 1 when the signature could be parsed, 0 otherwise.
-;; Args: ctx:      a secp256k1 context object
-;; Out:  sig:      a pointer to a signature object
-;; In:   input64:  a pointer to the 64-byte array to parse
+;; Args: ctx:      pointer to a context object
+;; Out:  sig:      pointer to a signature object
+;; In:   input64:  pointer to the 64-byte array to parse
 ;;
 ;; The signature must consist of a 32-byte big endian R value, followed by a
 ;; 32-byte big endian S value. If R or S fall outside of [0..order-1], the
@@ -623,9 +626,9 @@
 ;; Parse a DER ECDSA signature.
 ;;
 ;; Returns: 1 when the signature could be parsed, 0 otherwise.
-;; Args: ctx:      a secp256k1 context object
-;; Out:  sig:      a pointer to a signature object
-;; In:   input:    a pointer to the signature to be parsed
+;; Args: ctx:      pointer to a context object
+;; Out:  sig:      pointer to a signature object
+;; In:   input:    pointer to the signature to be parsed
 ;;       inputlen: the length of the array pointed to be input
 ;;
 ;; This function will accept any valid DER encoded signature, even if the
@@ -748,13 +751,13 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Serialize an ECDSA signature in DER format.
 ;;
 ;; Returns: 1 if enough space was available to serialize, 0 otherwise
-;; Args:   ctx:       a secp256k1 context object
-;; Out:    output:    a pointer to an array to store the DER serialization
-;; In/Out: outputlen: a pointer to a length integer. Initially, this integer
+;; Args:   ctx:       pointer to a context object
+;; Out:    output:    pointer to an array to store the DER serialization
+;; In/Out: outputlen: pointer to a length integer. Initially, this integer
 ;;                    should be set to the length of output. After the call
 ;;                    it will be set to the length of the serialization (even
 ;;                    if 0 was returned).
-;; In:     sig:       a pointer to an initialized signature object
+;; In:     sig:       pointer to an initialized signature object
 ;;
 (defcfun "secp256k1_ecdsa_signature_serialize_der" :int
   (ctx       (:pointer (:struct secp256k1-context)))
@@ -776,9 +779,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Serialize an ECDSA signature in compact (64 byte) format.
 ;;
 ;; Returns: 1
-;; Args:   ctx:       a secp256k1 context object
-;; Out:    output64:  a pointer to a 64-byte array to store the compact serialization
-;; In:     sig:       a pointer to an initialized signature object
+;; Args:   ctx:       pointer to a context object
+;; Out:    output64:  pointer to a 64-byte array to store the compact serialization
+;; In:     sig:       pointer to an initialized signature object
 ;;
 ;; See secp256k1_ecdsa_signature_parse_compact for details about the encoding.
 ;;
@@ -800,7 +803,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;
 ;; Returns: 1: correct signature
 ;;          0: incorrect or unparseable signature
-;; Args:    ctx:       a secp256k1 context object.
+;; Args:    ctx:       pointer to a context object
 ;; In:      sig:       the signature being verified.
 ;;          msghash32: the 32-byte message hash being verified.
 ;;                     The verifier must make sure to apply a cryptographic
@@ -843,12 +846,12 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Convert a signature to a normalized lower-S form.
 ;;
 ;; Returns: 1 if sigin was not normalized, 0 if it already was.
-;; Args: ctx:    a secp256k1 context object
-;; Out:  sigout: a pointer to a signature to fill with the normalized form,
+;; Args: ctx:    pointer to a context object
+;; Out:  sigout: pointer to a signature to fill with the normalized form,
 ;;               or copy if the input was already normalized. (can be NULL if
 ;;               you're only interested in whether the input was already
 ;;               normalized).
-;; In:   sigin:  a pointer to a signature to check/normalize (can be identical to sigout)
+;; In:   sigin:  pointer to a signature to check/normalize (can be identical to sigout)
 ;;
 ;; With ECDSA a third-party can forge a second distinct signature of the same
 ;; message, given a single initial signature, but without knowing the key. This
@@ -910,7 +913,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: 1: signature created
 ;;          0: the nonce generation function failed, or the secret key was invalid.
 ;; Args:    ctx:       pointer to a context object (not secp256k1_context_static).
-;; Out:     sig:       pointer to an array where the signature will be placed.
+;; Out:     sig:       pointer to a signature object.
 ;; In:      msghash32: the 32-byte message hash being signed.
 ;;          seckey:    pointer to a 32-byte secret key.
 ;;          noncefp:   pointer to a nonce generation function. If NULL,
@@ -945,12 +948,14 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
            (bytes-from-foreign nil csignature 64))
       (bytes-clear-foreign cseckey 32))))
 
-;; Verify an ECDSA secret key.
+;; Verify an elliptic curve secret key.
 ;;
 ;; A secret key is valid if it is not 0 and less than the secp256k1 curve order
 ;; when interpreted as an integer (most significant byte first). The
 ;; probability of choosing a 32-byte string uniformly at random which is an
-;; invalid secret key is negligible.
+;; invalid secret key is negligible. However, if it does happen it should
+;; be assumed that the randomness source is severely broken and there should
+;; be no retry.
 ;;
 ;; Returns: 1: secret key is valid
 ;;          0: secret key is invalid
@@ -1043,10 +1048,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;                 invalid according to secp256k1_ec_seckey_verify, this
 ;;                 function returns 0. seckey will be set to some unspecified
 ;;                 value if this function returns 0.
-;; In:    tweak32: pointer to a 32-byte tweak. If the tweak is invalid according to
-;;                 secp256k1_ec_seckey_verify, this function returns 0. For
-;;                 uniformly random 32-byte arrays the chance of being invalid
-;;                 is negligible (around 1 in 2^128).
+;; In:    tweak32: pointer to a 32-byte tweak, which must be valid according to
+;;                 secp256k1_ec_seckey_verify or 32 zero bytes. For uniformly
+;;                 random 32-byte tweaks, the chance of being invalid is
+;;                 negligible (around 1 in 2^128).
 ;;
 (defcfun "secp256k1_ec_seckey_tweak_add" :int
   (ctx    (:pointer (:struct secp256k1-context)))
@@ -1061,10 +1066,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Args:    ctx:   pointer to a context object.
 ;; In/Out: pubkey: pointer to a public key object. pubkey will be set to an
 ;;                 invalid value if this function returns 0.
-;; In:    tweak32: pointer to a 32-byte tweak. If the tweak is invalid according to
-;;                 secp256k1_ec_seckey_verify, this function returns 0. For
-;;                 uniformly random 32-byte arrays the chance of being invalid
-;;                 is negligible (around 1 in 2^128).
+;; In:    tweak32: pointer to a 32-byte tweak, which must be valid according to
+;;                 secp256k1_ec_seckey_verify or 32 zero bytes. For uniformly
+;;                 random 32-byte tweaks, the chance of being invalid is
+;;                 negligible (around 1 in 2^128).
 ;;
 (defcfun "secp256k1_ec_pubkey_tweak_add" :int
   (ctx    (:pointer (:struct secp256k1-context)))
@@ -1198,7 +1203,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;          0: scalar was invalid (zero or overflow) or hashfp returned 0
 ;; Args:    ctx:        pointer to a context object.
 ;; Out:     output:     pointer to an array to be filled by hashfp.
-;; In:      pubkey:     a pointer to a secp256k1_pubkey containing an initialized public key.
+;; In:      pubkey:     pointer to a secp256k1_pubkey containing an initialized public key.
 ;;          seckey:     a 32-byte scalar with which to multiply the point.
 ;;          hashfp:     pointer to a hash function. If NULL,
 ;;                      secp256k1_ecdh_hash_function_sha256 is used
@@ -1453,8 +1458,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; in the memory. In simpler words, the prealloc pointer (or any pointer derived
 ;; from it) should not be used during the lifetime of the context object.
 ;;
-;; Returns: a newly created context object.
-;; In:      prealloc: a pointer to a rewritable contiguous block of memory of
+;; Returns: pointer to newly created context object.
+;; In:      prealloc: pointer to a rewritable contiguous block of memory of
 ;;                    size at least secp256k1_context_preallocated_size(flags)
 ;;                    bytes, as detailed above.
 ;;          flags:    which parts of the context to initialize.
@@ -1472,7 +1477,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; caller-provided memory.
 ;;
 ;; Returns: the required size of the caller-provided memory block.
-;; In:      ctx: an existing context to copy.
+;; In:      ctx: pointer to a context to copy.
 ;;
 (defcfun "secp256k1_context_preallocated_clone_size" :size
   (ctx (:pointer (:struct secp256k1-context))))
@@ -1487,9 +1492,12 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; the lifetime of this context object, see the description of
 ;; secp256k1_context_preallocated_create for details.
 ;;
-;; Returns: a newly created context object.
-;; Args:    ctx:      an existing context to copy.
-;; In:      prealloc: a pointer to a rewritable contiguous block of memory of
+;; Cloning secp256k1_context_static is not possible, and should not be emulated by
+;; the caller (e.g., using memcpy). Create a new context instead.
+;;
+;; Returns: pointer to a newly created context object.
+;; Args:    ctx:      pointer to a context to copy (not secp256k1_context_static).
+;; In:      prealloc: pointer to a rewritable contiguous block of memory of
 ;;                    size at least secp256k1_context_preallocated_size(flags)
 ;;                    bytes, as detailed above.
 ;;
@@ -1513,9 +1521,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; preallocated pointer given to secp256k1_context_preallocated_create or
 ;; secp256k1_context_preallocated_clone.
 ;;
-;; Args:   ctx: an existing context to destroy, constructed using
+;; Args:   ctx: pointer to a context to destroy, constructed using
 ;;              secp256k1_context_preallocated_create or
-;;              secp256k1_context_preallocated_clone.
+;;              secp256k1_context_preallocated_clone
+;;              (i.e., not secp256k1_context_static).
 ;;
 (defcfun "secp256k1_context_preallocated_destroy" :void
  (ctx (:pointer (:struct secp256k1-context))))
@@ -1524,7 +1533,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;;-----------------------------------------------------------------------------
 ;;; secp256k1_recovery.h
 
-;; Opaque data structured that holds a parsed ECDSA signature,
+;; Opaque data structure that holds a parsed ECDSA signature,
 ;; supporting pubkey recovery.
 ;;
 ;; The exact representation of data inside is implementation defined and not
@@ -1544,9 +1553,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Parse a compact ECDSA signature (64 bytes + recovery id).
 ;;
 ;; Returns: 1 when the signature could be parsed, 0 otherwise
-;; Args: ctx:     a secp256k1 context object
-;; Out:  sig:     a pointer to a signature object
-;; In:   input64: a pointer to a 64-byte compact signature
+;; Args: ctx:     pointer to a context object
+;; Out:  sig:     pointer to a signature object
+;; In:   input64: pointer to a 64-byte compact signature
 ;;       recid:   the recovery id (0, 1, 2 or 3)
 ;;
 (defcfun "secp256k1_ecdsa_recoverable_signature_parse_compact" :int
@@ -1558,9 +1567,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Convert a recoverable signature into a normal signature.
 ;;
 ;; Returns: 1
-;; Args: ctx:    a secp256k1 context object.
-;; Out:  sig:    a pointer to a normal signature.
-;; In:   sigin:  a pointer to a recoverable signature.
+;; Args: ctx:    pointer to a context object.
+;; Out:  sig:    pointer to a normal signature.
+;; In:   sigin:  pointer to a recoverable signature.
 ;;
 (defcfun "secp256k1_ecdsa_recoverable_signature_convert" :int
   (ctx   (:pointer (:struct secp256k1-context)))
@@ -1570,10 +1579,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Serialize an ECDSA signature in compact format (64 bytes + recovery id).
 ;;
 ;; Returns: 1
-;; Args: ctx:      a secp256k1 context object.
-;; Out:  output64: a pointer to a 64-byte array of the compact signature.
-;;       recid:    a pointer to an integer to hold the recovery id.
-;; In:   sig:      a pointer to an initialized signature object.
+;; Args: ctx:      pointer to a context object.
+;; Out:  output64: pointer to a 64-byte array of the compact signature.
+;;       recid:    pointer to an integer to hold the recovery id.
+;; In:   sig:      pointer to an initialized signature object.
 ;;
 (defcfun "secp256k1_ecdsa_recoverable_signature_serialize_compact" :int
   (ctx      (:pointer (:struct secp256k1-context)))
@@ -1586,7 +1595,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: 1: signature created
 ;;          0: the nonce generation function failed, or the secret key was invalid.
 ;; Args:    ctx:       pointer to a context object (not secp256k1_context_static).
-;; Out:     sig:       pointer to an array where the signature will be placed.
+;; Out:     sig:       pointer to a signature object.
 ;; In:      msghash32: the 32-byte message hash being signed.
 ;;          seckey:    pointer to a 32-byte secret key.
 ;;          noncefp:   pointer to a nonce generation function. If NULL,
@@ -1604,7 +1613,17 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 
 ;; Recover an ECDSA public key from a signature.
 ;;
-;; Returns: 1: public key successfully recovered (which guarantees a correct signature).
+;; Successful public key recovery guarantees that the signature, after normalization,
+;; passes `secp256k1_ecdsa_verify`. Thus, explicit verification is not necessary.
+;;
+;; However, a recoverable signature that successfully passes `secp256k1_ecdsa_recover`,
+;; when converted to a non-recoverable signature (using
+;; `secp256k1_ecdsa_recoverable_signature_convert`), is not guaranteed to be
+;; normalized and thus not guaranteed to pass `secp256k1_ecdsa_verify`. If a
+;; normalized signature is required, call `secp256k1_ecdsa_signature_normalize`
+;; after `secp256k1_ecdsa_recoverable_signature_convert`.
+;;
+;; Returns: 1: public key successfully recovered
 ;;          0: otherwise.
 ;; Args:    ctx:       pointer to a context object.
 ;; Out:     pubkey:    pointer to the recovered public key.
@@ -1651,7 +1670,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: 1 if the public key was fully valid.
 ;;          0 if the public key could not be parsed or is invalid.
 ;;
-;; Args:   ctx: a secp256k1 context object.
+;; Args:   ctx: pointer to a context object.
 ;; Out: pubkey: pointer to a pubkey object. If 1 is returned, it is set to a
 ;;              parsed version of input. If not, it's set to an invalid value.
 ;; In: input32: pointer to a serialized xonly_pubkey.
@@ -1665,9 +1684,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;
 ;; Returns: 1 always.
 ;;
-;; Args:     ctx: a secp256k1 context object.
-;; Out: output32: a pointer to a 32-byte array to place the serialized key in.
-;; In:    pubkey: a pointer to a secp256k1_xonly_pubkey containing an initialized public key.
+;; Args:     ctx: pointer to a context object.
+;; Out: output32: pointer to a 32-byte array to place the serialized key in.
+;; In:    pubkey: pointer to a secp256k1_xonly_pubkey containing an initialized public key.
 ;;
 (defcfun "secp256k1_xonly_pubkey_serialize" :int
   (ctx      (:pointer (:struct secp256k1-context)))
@@ -1679,7 +1698,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: <0 if the first public key is less than the second
 ;;          >0 if the first public key is greater than the second
 ;;          0 if the two public keys are equal
-;; Args: ctx:      a secp256k1 context object.
+;; Args: ctx:      pointer to a context object.
 ;; In:   pubkey1:  first public key to compare
 ;;       pubkey2:  second public key to compare
 ;;
@@ -1720,10 +1739,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Out:  output_pubkey: pointer to a public key to store the result. Will be set
 ;;                      to an invalid value if this function returns 0.
 ;; In: internal_pubkey: pointer to an x-only pubkey to apply the tweak to.
-;;             tweak32: pointer to a 32-byte tweak. If the tweak is invalid
-;;                      according to secp256k1_ec_seckey_verify, this function
-;;                      returns 0. For uniformly random 32-byte arrays the
-;;                      chance of being invalid is negligible (around 1 in 2^128).
+;;             tweak32: pointer to a 32-byte tweak, which must be valid
+;;                      according to secp256k1_ec_seckey_verify or 32 zero
+;;                      bytes. For uniformly random 32-byte tweaks, the chance of
+;;                      being invalid is negligible (around 1 in 2^128).
 ;;
 (defcfun "secp256k1_xonly_pubkey_tweak_add" :int
   (ctx             (:pointer (:struct secp256k1-context)))
@@ -1762,10 +1781,13 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (internal-pubkey   (:pointer (:struct secp256k1-xonly-pubkey)))
   (tweak32           (:pointer :unsigned-char)))
 
-;; Compute the keypair for a secret key.
+;; Compute the keypair for a valid secret key.
 ;;
-;; Returns: 1: secret was valid, keypair is ready to use
-;;          0: secret was invalid, try again with a different secret
+;; See the documentation of `secp256k1_ec_seckey_verify` for more information
+;; about the validity of secret keys.
+;;
+;; Returns: 1: secret key is valid
+;;          0: secret key is invalid
 ;; Args:    ctx: pointer to a context object (not secp256k1_context_static).
 ;; Out: keypair: pointer to the created keypair.
 ;; In:   seckey: pointer to a 32-byte secret key.
@@ -1790,9 +1812,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Get the public key from a keypair.
 ;;
 ;; Returns: 1 always.
-;; Args:    ctx: pointer to a context object.
-;; Out: pubkey: pointer to a pubkey object. If 1 is returned, it is set to
-;;              the keypair public key. If not, it's set to an invalid value.
+;; Args:   ctx: pointer to a context object.
+;; Out: pubkey: pointer to a pubkey object, set to the keypair public key.
 ;; In: keypair: pointer to a keypair.
 ;;
 (defcfun "secp256k1_keypair_pub" :int
@@ -1807,9 +1828,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;
 ;; Returns: 1 always.
 ;; Args:   ctx: pointer to a context object.
-;; Out: pubkey: pointer to an xonly_pubkey object. If 1 is returned, it is set
-;;              to the keypair public key after converting it to an
-;;              xonly_pubkey. If not, it's set to an invalid value.
+;; Out: pubkey: pointer to an xonly_pubkey object, set to the keypair
+;;              public key after converting it to an xonly_pubkey.
 ;;   pk_parity: Ignored if NULL. Otherwise, pointer to an integer that will be set to the
 ;;              pk_parity argument of secp256k1_xonly_pubkey_from_pubkey.
 ;; In: keypair: pointer to a keypair.
@@ -1834,10 +1854,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Args:       ctx: pointer to a context object.
 ;; In/Out: keypair: pointer to a keypair to apply the tweak to. Will be set to
 ;;                  an invalid value if this function returns 0.
-;; In:     tweak32: pointer to a 32-byte tweak. If the tweak is invalid according
-;;                  to secp256k1_ec_seckey_verify, this function returns 0. For
-;;                  uniformly random 32-byte arrays the chance of being invalid
-;;                  is negligible (around 1 in 2^128).
+;; In:     tweak32: pointer to a 32-byte tweak, which must be valid according to
+;;                  secp256k1_ec_seckey_verify or 32 zero bytes. For uniformly
+;;                  random 32-byte tweaks, the chance of being invalid is
+;;                  negligible (around 1 in 2^128).
 ;;
 (defcfun "secp256k1_keypair_xonly_tweak_add" :int
   (ctx     (:pointer (:struct secp256k1-context)))
@@ -1960,16 +1980,24 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 
 ;; Create a Schnorr signature with a more flexible API.
 ;;
-;; Same arguments as secp256k1_schnorrsig_sign except that it allows signing
+;; Same arguments as secp256k1_schnorrsig_sign32 except that it allows signing
 ;; variable length messages and accepts a pointer to an extraparams object that
 ;; allows customizing signing by passing additional arguments.
 ;;
-;; Creates the same signatures as schnorrsig_sign if msglen is 32 and the
-;; extraparams.ndata is the same as aux_rand32.
+;; Equivalent to secp256k1_schnorrsig_sign32(..., aux_rand32) if msglen is 32
+;; and extraparams is initialized as follows:
+;; ```
+;; secp256k1_schnorrsig_extraparams extraparams = SECP256K1_SCHNORRSIG_EXTRAPARAMS_INIT;
+;; extraparams.ndata = (unsigned char*)aux_rand32;
+;; ```
 ;;
+;; Returns 1 on success, 0 on failure.
+;; Args:   ctx: pointer to a context object (not secp256k1_context_static).
+;; Out:  sig64: pointer to a 64-byte array to store the serialized signature.
 ;; In:     msg: the message being signed. Can only be NULL if msglen is 0.
-;;      msglen: length of the message
-;; extraparams: pointer to a extraparams object (can be NULL)
+;;      msglen: length of the message.
+;;     keypair: pointer to an initialized keypair.
+;; extraparams: pointer to an extraparams object (can be NULL).
 ;;
 (defcfun "secp256k1_schnorrsig_sign_custom" :int
   (ctx         (:pointer (:struct secp256k1-context)))
@@ -1983,11 +2011,11 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;;
 ;; Returns: 1: correct signature
 ;;          0: incorrect signature
-;; Args:    ctx: a secp256k1 context object.
+;; Args:    ctx: pointer to a context object.
 ;; In:    sig64: pointer to the 64-byte signature to verify.
 ;;          msg: the message being verified. Can only be NULL if msglen is 0.
 ;;       msglen: length of the message
-;;       pubkey: pointer to an x-only public key to verify with (cannot be NULL)
+;;       pubkey: pointer to an x-only public key to verify with
 ;;
 (defcfun "secp256k1_schnorrsig_verify" :int
   (ctx    (:pointer (:struct secp256k1-context)))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -1718,7 +1718,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (noncefp secp256k1-nonce-function-hardened)
   (ndata   :pointer)) ;; void*
 
-(defconstant +secp256k1-schnorrsig-extraparams-magic+ '(0xda 0x6f 0xb3 0x8c))
+(defconstant +secp256k1-schnorrsig-extraparams-magic+ '(#xda #x6f #xb3 #x8c))
 
 ;; Create a Schnorr signature.
 ;;

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -88,6 +88,13 @@
         :for i :below size
         :do (setf (mem-aref pointer :unsigned-char i) (aref bytes i)))))
 
+(defmacro bytes-clear-foreign (pointer size)
+  `(let ((pointer ,pointer)
+         (size ,size))
+     (loop
+        :for i :below size
+        :do (setf (mem-aref pointer :unsigned-char i) 0))))
+
 
 ;;;-----------------------------------------------------------------------------
 ;;; secp256k1.h
@@ -363,8 +370,10 @@
   (with-foreign-objects
       ((cseed32 :unsigned-char 32))
     (bytes-to-foreign (random-bytes 32) cseed32 32)
-    (assert (not (zerop (secp256k1-context-randomize ctx cseed32)))
-            () "Context randomization error."))
+    (unwind-protect
+         (assert (not (zerop (secp256k1-context-randomize ctx cseed32)))
+                 () "Context randomization error.")
+      (bytes-clear-foreign cseed32 32)))
   ctx)
 
 (defvar *secp256k1-context* (context-randomize (context-create)))
@@ -879,9 +888,11 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
        (cseckey :unsigned-char 32))
     (bytes-to-foreign msg32 cmsg32 32)
     (bytes-to-foreign seckey cseckey 32)
-    (unless (zerop (secp256k1-ecdsa-sign *secp256k1-context* csignature cmsg32 cseckey
-                                         (null-pointer) (null-pointer)))
-      (bytes-from-foreign nil csignature 64))))
+    (unwind-protect
+         (unless (zerop (secp256k1-ecdsa-sign *secp256k1-context* csignature cmsg32 cseckey
+                                              (null-pointer) (null-pointer)))
+           (bytes-from-foreign nil csignature 64))
+      (bytes-clear-foreign cseckey 32))))
 
 ;; Verify an ECDSA secret key.
 ;;
@@ -903,8 +914,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (with-foreign-objects
       ((cseckey :unsigned-char 32))
     (bytes-to-foreign seckey cseckey 32)
-    (unless (zerop (secp256k1-ec-seckey-verify *secp256k1-context* cseckey))
-      t)))
+    (unwind-protect
+         (unless (zerop (secp256k1-ec-seckey-verify *secp256k1-context* cseckey))
+           t)
+      (bytes-clear-foreign cseckey 32))))
 
 ;; Compute the public key for a secret key.
 ;;
@@ -924,8 +937,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
       ((cpubkey '(:struct secp256k1-pubkey))
        (cseckey :unsigned-char 32))
     (bytes-to-foreign seckey cseckey 32)
-    (unless (zerop (secp256k1-ec-pubkey-create *secp256k1-context* cpubkey cseckey))
-      (bytes-from-foreign nil cpubkey 64))))
+    (unwind-protect
+         (unless (zerop (secp256k1-ec-pubkey-create *secp256k1-context* cpubkey cseckey))
+           (bytes-from-foreign nil cpubkey 64))
+      (bytes-clear-foreign cseckey 32))))
 
 ;; Negates a secret key in place.
 ;;
@@ -945,8 +960,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (with-foreign-objects
       ((cseckey :unsigned-char 32))
     (bytes-to-foreign seckey cseckey 32)
-    (unless (zerop (secp256k1-ec-seckey-negate *secp256k1-context* cseckey))
-      (bytes-from-foreign seckey cseckey 32))))
+    (unwind-protect
+         (unless (zerop (secp256k1-ec-seckey-negate *secp256k1-context* cseckey))
+           (bytes-from-foreign seckey cseckey 32))
+      (bytes-clear-foreign cseckey 32))))
 
 ;; Negates a public key in place.
 ;;

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -71,10 +71,6 @@
 
 (use-foreign-library libsecp256k1)
 
-;; This is incorrect but fits both 64-bit Linux and 64-bit macOS, so
-;; is good enough for now.
-(defctype size :unsigned-long)
-
 (defmacro bytes-from-foreign (bytes pointer size)
   `(let* ((pointer ,pointer)
           (size ,size)
@@ -460,7 +456,7 @@
   (ctx      (:pointer (:struct secp256k1-context)))
   (pubkey   (:pointer (:struct secp256k1-pubkey)))
   (input    (:pointer :unsigned-char))
-  (inputlen size))
+  (inputlen :size))
 
 (defun ec-pubkey-parse (input)
   (let ((inputlen (length input)))
@@ -490,7 +486,7 @@
 (defcfun "secp256k1_ec_pubkey_serialize" :int
   (ctx       (:pointer (:struct secp256k1-context)))
   (output    (:pointer :unsigned-char))
-  (outputlen (:pointer size))
+  (outputlen (:pointer :size))
   (pubkey    (:pointer (:struct secp256k1-pubkey)))
   (flags     :unsigned-int))
 
@@ -498,15 +494,15 @@
   (let ((outputlen (if compressed 33 65)))
     (with-foreign-objects
         ((coutput :unsigned-char outputlen)
-         (coutputlen 'size 1)
+         (coutputlen :size 1)
          (cpubkey '(:struct secp256k1-pubkey)))
-      (setf (mem-aref coutputlen 'size 0) outputlen)
+      (setf (mem-aref coutputlen :size 0) outputlen)
       (bytes-to-foreign pubkey cpubkey 64)
       (secp256k1-ec-pubkey-serialize *secp256k1-context* coutput coutputlen cpubkey
                                      (if compressed
                                          +secp256k1-ec-compressed+
                                          +secp256k1-ec-uncompressed+))
-      (bytes-from-foreign nil coutput (mem-aref coutputlen :unsigned-int 0)))))
+      (bytes-from-foreign nil coutput (mem-aref coutputlen :size 0)))))
 
 ;; Compare two public keys using lexicographic (of compressed serialization) order
 ;;
@@ -533,7 +529,7 @@
 (defcfun "secp256k1_ec_pubkey_sort" :int
   (ctx       (:pointer (:struct secp256k1-context)))
   (pubkeys   (:pointer (:pointer (:struct secp256k1-pubkey))))
-  (n-pubkeys size))
+  (n-pubkeys :size))
 
 ;; Parse an ECDSA signature in compact (64 bytes) format.
 ;;
@@ -583,7 +579,7 @@
   (ctx      (:pointer (:struct secp256k1-context)))
   (sig      (:pointer (:struct secp256k1-ecdsa-signature)))
   (input    (:pointer :unsigned-char))
-  (inputlen size))
+  (inputlen :size))
 
 (defun ecdsa-signature-parse-der (input)
   (let ((inputlen (length input)))
@@ -703,19 +699,19 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 (defcfun "secp256k1_ecdsa_signature_serialize_der" :int
   (ctx       (:pointer (:struct secp256k1-context)))
   (output    (:pointer :unsigned-char))
-  (outputlen (:pointer size))
+  (outputlen (:pointer :size))
   (sig       (:pointer (:struct secp256k1-ecdsa-signature))))
 
 (defun ecdsa-signature-serialize-der (signature)
   (with-foreign-objects
       ((coutput :unsigned-char 74)
-       (coutputlen 'size 1)
+       (coutputlen :size 1)
        (csignature '(:struct secp256k1-ecdsa-signature)))
-    (setf (mem-aref coutputlen 'size 0) 74)
+    (setf (mem-aref coutputlen :size 0) 74)
     (bytes-to-foreign signature csignature 64)
     (unless (zerop (secp256k1-ecdsa-signature-serialize-der
                     *secp256k1-context* coutput coutputlen csignature))
-      (bytes-from-foreign nil coutput (mem-aref coutputlen 'size 0)))))
+      (bytes-from-foreign nil coutput (mem-aref coutputlen :size 0)))))
 
 ;; Serialize an ECDSA signature in compact (64 byte) format.
 ;;
@@ -1054,7 +1050,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ctx (:pointer (:struct secp256k1-context)))
   (out (:pointer (:struct secp256k1-pubkey)))
   (ins (:pointer (:pointer (:struct secp256k1-pubkey))))
-  (n   size))
+  (n   :size))
 
 (defun ec-pubkey-combine (ins)
   (let ((n (length ins)))
@@ -1091,9 +1087,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ctx    (:pointer (:struct secp256k1-context)))
   (hash32 (:pointer :unsigned-char))
   (tag    (:pointer :unsigned-char))
-  (taglen size)
+  (taglen :size)
   (msg    (:pointer :unsigned-char))
-  (msglen size))
+  (msglen :size))
 
 
 ;;;-----------------------------------------------------------------------------
@@ -1370,7 +1366,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: the required size of the caller-provided memory block
 ;; In:      flags:    which parts of the context to initialize.
 ;;
-(defcfun "secp256k1_context_preallocated_size" size
+(defcfun "secp256k1_context_preallocated_size" :size
   (flags :unsigned-int))
 
 ;; Create a secp256k1 context object in caller-provided memory.
@@ -1410,7 +1406,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 ;; Returns: the required size of the caller-provided memory block.
 ;; In:      ctx: an existing context to copy.
 ;;
-(defcfun "secp256k1_context_preallocated_clone_size" size
+(defcfun "secp256k1_context_preallocated_clone_size" :size
   (ctx (:pointer (:struct secp256k1-context))))
 
 ;; Copy a secp256k1 context object into caller-provided memory.
@@ -1920,7 +1916,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ctx         (:pointer (:struct secp256k1-context)))
   (sig64       (:pointer :unsigned-char))
   (msg         (:pointer :unsigned-char))
-  (msglen      size)
+  (msglen      :size)
   (keypair     (:pointer (:struct secp256k1-keypair)))
   (extraparams (:pointer (:struct secp256k1-schnorrsig-extraparams))))
 
@@ -1938,7 +1934,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ctx    (:pointer (:struct secp256k1-context)))
   (sig64  (:pointer :unsigned-char))
   (msg    (:pointer :unsigned-char))
-  (msglen size)
+  (msglen :size)
   (pubkey (:pointer (:struct secp256k1-xonly-pubkey))))
 
 
@@ -2124,7 +2120,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (agg-pk       (:pointer (:struct secp256k1-xonly-pubkey)))
   (keyagg-cache (:pointer (:struct secp256k1-musig-keyagg-cache)))
   (pubkeys      (:pointer (:pointer (:struct secp256k1-pubkey))))
-  (n-pubkeys    size))
+  (n-pubkeys    :size))
 
 ;; Obtain the aggregate public key from a keyagg_cache.
 ;;
@@ -2372,7 +2368,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ctx         (:pointer (:struct secp256k1-context)))
   (aggnonce    (:pointer (:struct secp256k1-musig-aggnonce)))
   (pubnonces   (:pointer (:pointer (:struct secp256k1-musig-pubnonce))))
-  (n-pubnonces size))
+  (n-pubnonces :size))
 
 ;; Takes the aggregate nonce and creates a session that is required for signing
 ;; and verification of partial signatures.
@@ -2490,7 +2486,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (sig64        (:pointer :unsigned-char))
   (session      (:pointer (:struct secp256k1-musig-session)))
   (partial-sigs (:pointer (:pointer (:struct secp256k1-musig-partial-sig))))
-  (n-sigs       size))
+  (n-sigs       :size))
 
 
 ;;;-----------------------------------------------------------------------------

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -1610,7 +1610,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 (defcfun "secp256k1_keypair_xonly_pub" :int
   (ctx       (:pointer (:struct secp256k1-context)))
   (pubkey    (:pointer (:struct secp256k1-xonly-pubkey)))
-  (pk-parity :int)
+  (pk-parity (:pointer :int))
   (keypair   (:pointer (:struct secp256k1-keypair))))
 
 ;; Tweak a keypair by adding tweak32 to the secret key and updating the public

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -970,8 +970,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (with-foreign-objects
       ((cseckey :unsigned-char 32))
     (bytes-to-foreign seckey cseckey 32)
-    (secp256k1-ec-privkey-negate *secp256k1-context* cseckey)
-    (bytes-from-foreign seckey cseckey 32)))
+    (unless (zerop (secp256k1-ec-seckey-negate *secp256k1-context* cseckey))
+      (bytes-from-foreign seckey cseckey 32))))
 
 ;; Same as secp256k1_ec_seckey_negate, but DEPRECATED. Will be removed in
 ;; future versions.
@@ -1116,8 +1116,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
         :for cin := (mem-aptr cins '(:struct secp256k1-pubkey) i)
         :do (bytes-to-foreign in cin 64)
             (setf (mem-aref pins '(:pointer (:struct secp256k1-pubkey)) i) cin))
-      (secp256k1-ec-pubkey-combine *secp256k1-context* cpubkey pins n)
-      (bytes-from-foreign nil cpubkey 64))))
+      (unless (zerop (secp256k1-ec-pubkey-combine *secp256k1-context* cpubkey pins n))
+        (bytes-from-foreign nil cpubkey 64)))))
 
 ;; Compute a tagged hash as defined in BIP-340.
 ;;
@@ -1849,6 +1849,6 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
     (ecdsa-verify (or nbytes bytes) hash (pubkey-bytes pubkey))))
 
 (defun combine-pubkeys (&rest pubkeys)
-  (%make-pubkey
-   :bytes
-   (ec-pubkey-combine (mapcar #'pubkey-bytes pubkeys))))
+  (let ((bytes (ec-pubkey-combine (mapcar #'pubkey-bytes pubkeys))))
+    (when bytes
+      (%make-pubkey :bytes bytes))))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -2508,7 +2508,9 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (%make-pubkey :bytes (ec-pubkey-create (key-bytes key))))
 
 (defun parse-pubkey (bytes)
-  (%make-pubkey :bytes (ec-pubkey-parse bytes)))
+  (let ((bytes (ec-pubkey-parse bytes)))
+    (when bytes
+      (%make-pubkey :bytes bytes))))
 
 (defun serialize-pubkey (pubkey &key compressed)
   (ec-pubkey-serialize (pubkey-bytes pubkey) :compressed compressed))
@@ -2521,7 +2523,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
                   (ecdsa-signature-parse-der bytes))
                  (:relaxed
                   (ecdsa-signature-parse-der-lax bytes)))))
-    (%make-signature :bytes bytes)))
+    (when bytes
+      (%make-signature :bytes bytes))))
 
 (defun serialize-signature (signature &key (type :der))
   (ecase type
@@ -2534,9 +2537,10 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (%make-signature :bytes (ecdsa-sign hash (key-bytes key))))
 
 (defun verify-signature (pubkey hash signature)
-  (let* ((bytes  (signature-bytes signature))
-         (nbytes (ecdsa-signature-normalize bytes)))
-    (ecdsa-verify (or nbytes bytes) hash (pubkey-bytes pubkey))))
+  (when (and pubkey signature)
+    (let* ((bytes  (signature-bytes signature))
+           (nbytes (ecdsa-signature-normalize bytes)))
+      (ecdsa-verify (or nbytes bytes) hash (pubkey-bytes pubkey)))))
 
 (defun combine-pubkeys (&rest pubkeys)
   (let ((bytes (ec-pubkey-combine (mapcar #'pubkey-bytes pubkeys))))


### PR DESCRIPTION
This PR updates the `bp.crypto.secp256k1` subsystem to the ~0.7.1~ 0.8.0 version, adds all missing declarations and fixes a couple of bugs.